### PR TITLE
Issue #99 feat: Build registry app as jar instead of war

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ local.properties
 .loadpath
 .recommenders
 
+logs
+
 # External tool builders
 .externalToolBuilders/
 

--- a/java/converters/rdf2Graph/pom.xml
+++ b/java/converters/rdf2Graph/pom.xml
@@ -8,7 +8,6 @@
 		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
-	<groupId>io.open-saber</groupId>
 	<artifactId>rdf2graph</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>

--- a/java/middleware/registry-middleware/rdf-validation/src/main/java/io/opensaber/registry/middleware/impl/RDFValidator.java
+++ b/java/middleware/registry-middleware/rdf-validation/src/main/java/io/opensaber/registry/middleware/impl/RDFValidator.java
@@ -2,22 +2,9 @@ package io.opensaber.registry.middleware.impl;
 
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
 
-import javax.management.relation.RelationService;
-
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.github.jsonldjava.core.JsonLdConsts;
-import com.github.jsonldjava.core.JsonLdOptions;
-import com.github.jsonldjava.core.JsonLdProcessor;
-import com.github.jsonldjava.utils.JsonUtils;
 
 import es.weso.schema.Result;
 import es.weso.schema.Schema;
@@ -26,21 +13,17 @@ import io.opensaber.registry.middleware.MiddlewareHaltException;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.validators.shex.shaclex.ShaclexValidator;
 
-/**
- * 
- * @author steotia
- *
- */
 public class RDFValidator implements BaseMiddleware{
 
 	private static final String RDF_DATA_IS_MISSING = "RDF Data is missing!";
 	private static final String RDF_DATA_IS_INVALID = "RDF Data is invalid!";
-	private Path schemaFilePath;	
-	public static final String SCHEMAFORMAT = "SHEXC";
-	public static final String PROCESSOR 	= "shex";
 
-	public RDFValidator(Path schemaFilePath){
-		this.schemaFilePath = schemaFilePath;
+	private String schemaFileName;
+	private static final String SCHEMAFORMAT = "SHEXC";
+	private static final String PROCESSOR 	= "shex";
+
+	public RDFValidator(String schemaFileName) {
+		this.schemaFileName = schemaFileName;
 	}
 
 	public Map<String, Object> execute(Map<String, Object> mapData) throws IOException, MiddlewareHaltException {
@@ -50,9 +33,11 @@ public class RDFValidator implements BaseMiddleware{
 			throw new MiddlewareHaltException(this.getClass().getName()+RDF_DATA_IS_MISSING); 
 		} else if (RDF instanceof Model) {
 			ShaclexValidator validator = new ShaclexValidator();
-			Schema schema = validator.readSchema(this.schemaFilePath,SCHEMAFORMAT, PROCESSOR);
+
+			Schema schema = validator.readSchema(schemaFileName, SCHEMAFORMAT, PROCESSOR);
 			Model rdfWithValidations = mergeModels((Model)RDF, (Model)validationRDF);
 			Result validationResult = validator.validate(rdfWithValidations, schema);
+
 			mapData.put(Constants.RDF_VALIDATION_OBJECT, validationResult);
 			if(!validationResult.isValid()){
 				throw new MiddlewareHaltException(this.getClass().getName()+RDF_DATA_IS_INVALID);

--- a/java/registry-interceptor/pom.xml
+++ b/java/registry-interceptor/pom.xml
@@ -14,7 +14,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.9.RELEASE</version>
+		<!-- <version>1.5.9.RELEASE</version> -->
+		<version>2.0.0.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -62,6 +63,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>

--- a/java/registry/docker-compose.yml
+++ b/java/registry/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '2'
-services:
-  web:
-    image: tomcat
-    ports: 
-      - "8080:8080"
-    volumes:
-      - ./target/registry.war:/usr/local/tomcat/webapps/ROOT.war
-      - ./target/registry:/usr/local/tomcat/webapps/ROOT
-      - ./databases:/var/lib/neo4j/data/databases
-    privileged: true
+jar:
+  image: frolvlad/alpine-oraclejdk8:slim
+  ports:
+    - "8080:8080"
+    - "9000:9000"
+  volumes:
+    - ./target/registry.jar:/registry.jar
+    - /data:/data
+    - ./logs:/logs
+  command: java -jar /registry.jar
+  privileged: true

--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -5,7 +5,8 @@
 	<groupId>io.opensaber</groupId>
 	<artifactId>registry</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<packaging>war</packaging>
+	<!-- <packaging>war</packaging> -->
+	<packaging>jar</packaging>
 
 	<name>registry</name>
 	<description>registry</description>
@@ -13,28 +14,32 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.9.RELEASE</version>
+		<!-- <version>1.5.9.RELEASE</version> -->
+		<version>2.0.0.RELEASE</version>
 		<relativePath />
-		<!-- <groupId>io.open-saber</groupId> <artifactId>open-saber</artifactId> 
-			<version>1.0.0-SNAPSHOT</version> -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<start-class>io.opensaber.registry.controller.RegistryController</start-class>
+		<!-- <start-class>io.opensaber.registry.controller.RegistryController</start-class> -->
 		<tinkerpop.version>3.3.1</tinkerpop.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		 </dependency>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>io.open-saber</groupId>
 			<artifactId>pojos</artifactId>
@@ -61,6 +66,11 @@
 			<artifactId>registry-interceptor</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>io.open-saber</groupId>
+			<artifactId>jenardf4j</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
 
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -82,25 +92,6 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.6</version>
 		</dependency>
-
-		<dependency>
-			<groupId>org.jmockit</groupId>
-			<artifactId>jmockit</artifactId>
-			<version>1.8</version>
-			<scope>test</scope>
-		</dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.7.13</version>
-            <scope>test</scope>
-        </dependency>
 
 		<dependency>
 			<groupId>org.neo4j</groupId>
@@ -165,8 +156,7 @@
 			<artifactId>sqlg-h2-dialect</artifactId>
 			<version>1.5.0</version>
 		</dependency>
-		<!-- <dependency> <groupId>org.neo4j</groupId> <artifactId>neo4j-tinkerpop-api-impl</artifactId> 
-			<version>0.7-3.2.3</version> </dependency> -->
+
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-model</artifactId>
@@ -187,7 +177,7 @@
 			<groupId>org.apache.tinkerpop</groupId>
 			<artifactId>tinkergraph-gremlin</artifactId>
 			<version>${tinkerpop.version}</version>
-		</dependency><!-- https://mvnrepository.com/artifact/org.json/json -->
+		</dependency>
 		<dependency>
 		    <groupId>org.json</groupId>
 		    <artifactId>json</artifactId>
@@ -215,11 +205,33 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
+		<!-- Test Dependencies -->
+
 		<dependency>
-			<groupId>io.open-saber</groupId>
-			<artifactId>jenardf4j</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jmockit</groupId>
+			<artifactId>jmockit</artifactId>
+			<version>1.8</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.7.13</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -229,7 +241,8 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
-					<warName>registry</warName>
+					<!-- <warName>registry</warName> -->
+					<!-- <excludeArtifactIds>spring-boot-starter-tomcat</excludeArtifactIds> -->
 				</configuration>
 			</plugin>
 		</plugins>

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -1,8 +1,5 @@
 package io.opensaber.registry.config;
 
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,17 +32,14 @@ import io.opensaber.registry.middleware.impl.RdfToJsonldConverter;
 import io.opensaber.registry.middleware.util.Constants;
 
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import scalaz.Const;
 
-/**
- * 
- * @author jyotsna
- *
- */
 @Configuration
 @PropertySource(value = {"classpath:config-${spring.profiles.active}.properties"})
-public class GenericConfiguration extends WebMvcConfigurerAdapter {
+// public class GenericConfiguration extends WebMvcConfigurerAdapter {
+public class GenericConfiguration implements WebMvcConfigurer {
 
 	private static Logger logger = LoggerFactory.getLogger(GenericConfiguration.class);
 
@@ -72,9 +66,7 @@ public class GenericConfiguration extends WebMvcConfigurerAdapter {
 	@Bean
 	public RDFValidator rdfValidator(){
 		String shexFileName = environment.getProperty(Constants.SHEX_PROPERTY_NAME);
-		String shexFilePath = this.getClass().getClassLoader().getResource(shexFileName).getPath();
-		Path filePath = Paths.get(shexFilePath);
-		return new RDFValidator(filePath);
+		return new RDFValidator(shexFileName);
 	}
 
 	/*

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -23,11 +23,9 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +36,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.opensaber.converters.JenaRDF4J;
 import io.opensaber.pojos.Response;
 import io.opensaber.pojos.ResponseParams;
 import io.opensaber.registry.exception.DuplicateRecordException;
@@ -49,16 +46,15 @@ import io.opensaber.registry.service.RegistryService;
 @RestController
 @SpringBootApplication
 @ComponentScan({"io.opensaber.registry"})
-public class RegistryController extends SpringBootServletInitializer {
+public class RegistryController {
 
 	private static Logger logger = LoggerFactory.getLogger(RegistryController.class);
 
 	@Autowired
-	RegistryService registryService;
+	private RegistryService registryService;
 
-	@Override
-	protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-		return application.sources(RegistryController.class);
+	public static void main(String[] args) {
+		SpringApplication.run(RegistryController.class, args);
 	}
 
 	@ResponseBody
@@ -80,7 +76,7 @@ public class RegistryController extends SpringBootServletInitializer {
 			responseParams.setStatus(Response.Status.UNSUCCESSFUL);
 			responseParams.setErrmsg(e.getMessage());
 		}
-		return new ResponseEntity<Response>(response, HttpStatus.OK);
+		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/getEntity/{id}", method = RequestMethod.GET)
@@ -106,7 +102,7 @@ public class RegistryController extends SpringBootServletInitializer {
 			responseParams.setErrmsg("Ding! You encountered an error!");
 			logger.error("ERROR!", e);
 		}
-		return new ResponseEntity<Response>(response, HttpStatus.OK);
+		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
 }

--- a/java/registry/src/main/resources/config-prod.properties
+++ b/java/registry/src/main/resources/config-prod.properties
@@ -18,3 +18,11 @@ school.shape.name=http://example.com/voc/teacher/1.0.0/SchoolShape
 school.shape.type=http://example.com/voc/teacher/1.0.0/School
 address.shape.name=http://example.com/voc/teacher/1.0.0/AddressShape
 address.shape.type=http://example.com/voc/teacher/1.0.0/IndianUrbanPostalAddress
+
+##############################################################
+#               SpringBoot Actuator Config                   #
+##############################################################
+
+management.security.enabled=false
+management.context.path=admin
+management.port=9000

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${CATALINA_HOME}/logs/registry-app.log</file>
+        <file>logs/registry-app.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
             <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>

--- a/java/validators/shex/shaclex/src/main/java/io/opensaber/validators/shex/shaclex/ShaclexValidator.java
+++ b/java/validators/shex/shaclex/src/main/java/io/opensaber/validators/shex/shaclex/ShaclexValidator.java
@@ -1,12 +1,14 @@
 package io.opensaber.validators.shex.shaclex;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import es.weso.schema.*;
+import org.apache.jena.ext.com.google.common.io.ByteStreams;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -63,6 +65,12 @@ public class ShaclexValidator {
 
 	public Schema readSchema(Path schemaFilePath, String format, String processor) throws IOException {
 		String contents = new String(Files.readAllBytes(schemaFilePath));
+		return Schemas.fromString(contents,format,processor,none).get();
+	}
+
+	public Schema readSchema(String schemaFileName, String format, String processor) throws IOException {
+		InputStream is = this.getClass().getClassLoader().getResourceAsStream(schemaFileName);
+		String contents = new String(ByteStreams.toByteArray(is));
 		return Schemas.fromString(contents,format,processor,none).get();
 	}
 


### PR DESCRIPTION
@steotia @jyotsna-tarento 

1. I have changed the build artifact to be jar instead of war as is the norm in all microservices or REST based services.
2. Springboot version has been upgraded to 2.0.0.RELEASE.
3. Use embedded tomcat as it helps us to scale the service horizontally.
4. SpringBootServletInitializer is not necessary for a Springboot application.
5. ShaclexValidator will use this.getClass().getClassLoader().getResourceAsStream(schemaFileName) to read the validation file. Using getResourceAsStream is a more robust way of reading resource files.
6. Use alpine jdk docker image to run the application using docker and java -jar commands.