### PR TITLE
OS-50 RegistryDaoLayer - refactoring first part

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -66,6 +66,9 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	@Value("${perf.monitoring.enabled}")
 	private boolean performanceMonitoringEnabled;
 
+	@Value("${registry.system.base}")
+	private String registrySystemBase;
+
 	@Bean
 	public ObjectMapper objectMapper() {
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -132,7 +135,7 @@ public class GenericConfiguration implements WebMvcConfigurer {
 
 		OpenSaberInstrumentation watch = instrumentationStopWatch();
 		watch.start("SchemaConfigurator.initialization");
-		SchemaConfigurator schemaConfigurator = new SchemaConfigurator(fieldConfigFileName, validationConfigFileForCreate, validationConfigFileForUpdate);
+		SchemaConfigurator schemaConfigurator = new SchemaConfigurator(fieldConfigFileName, validationConfigFileForCreate, validationConfigFileForUpdate, registrySystemBase);
 		watch.stop("SchemaConfigurator.initialization");
 		return schemaConfigurator ;
 	}

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import io.opensaber.pojos.OpenSaberInstrumentation;
 import io.opensaber.registry.authorization.KeyCloakServiceImpl;
 import io.opensaber.registry.sink.*;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.jena.rdf.model.Model;
@@ -194,6 +195,11 @@ public class GenericConfiguration implements WebMvcConfigurer {
 		}
 
 		return provider;
+	}
+
+	@Bean
+	public UrlValidator urlValidator(){
+		return new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
 	}
 
 	@Bean

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import io.opensaber.pojos.OpenSaberInstrumentation;
 import io.opensaber.registry.authorization.KeyCloakServiceImpl;
 import io.opensaber.registry.sink.*;
-
-import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.jena.rdf.model.Model;
@@ -38,7 +36,6 @@ import io.opensaber.registry.middleware.impl.JSONLDConverter;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.model.AuditRecord;
 import io.opensaber.registry.schema.config.SchemaConfigurator;
-
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -68,9 +65,6 @@ public class GenericConfiguration implements WebMvcConfigurer {
 
 	@Value("${perf.monitoring.enabled}")
 	private boolean performanceMonitoringEnabled;
-	
-	@Value("${registry.system.base}")
-	private String registrySystemBase;
 
 	@Bean
 	public ObjectMapper objectMapper() {
@@ -138,7 +132,7 @@ public class GenericConfiguration implements WebMvcConfigurer {
 
 		OpenSaberInstrumentation watch = instrumentationStopWatch();
 		watch.start("SchemaConfigurator.initialization");
-		SchemaConfigurator schemaConfigurator = new SchemaConfigurator(fieldConfigFileName, validationConfigFileForCreate, validationConfigFileForUpdate, registrySystemBase);
+		SchemaConfigurator schemaConfigurator = new SchemaConfigurator(fieldConfigFileName, validationConfigFileForCreate, validationConfigFileForUpdate);
 		watch.stop("SchemaConfigurator.initialization");
 		return schemaConfigurator ;
 	}
@@ -200,11 +194,6 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	}
 
 	@Bean
-	public UrlValidator urlValidator(){
-		return new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
-	}
-
-	@Bean
 	public Middleware rdfValidationMapper() {
 		Model validationConfig = null;
 		try{
@@ -222,13 +211,9 @@ public class GenericConfiguration implements WebMvcConfigurer {
                     .addPathPatterns("/**").excludePathPatterns("/health", "/error").order(1);
         }
 		registry.addInterceptor(rdfConversionInterceptor())
-				.addPathPatterns("/add", "/update","/search").order(2);
-		/*registry.addInterceptor(rdfValidationMappingInterceptor())
-				.addPathPatterns("/add", "/update").order(3);*/
+				.addPathPatterns("/add", "/update").order(2);
 		registry.addInterceptor(rdfValidationInterceptor())
 				.addPathPatterns("/add", "/update").order(3);
-	/*	registry.addInterceptor(new JSONLDConversionInterceptor(jsonldConverter()))
-				.addPathPatterns("/read/{id}").order(2);*/
 	}
 
 	@Override

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -38,7 +38,7 @@ public class RegistryController {
 
 	@Autowired
 	private RegistryService registryService;
-	
+
 	@Autowired
 	private SearchService searchService;
 
@@ -58,6 +58,7 @@ public class RegistryController {
 	public ResponseEntity<Response> add(@RequestAttribute Request requestModel, 
 			@RequestParam(value="id", required = false) String id, @RequestParam(value="prop", required = false) String property) {
 
+		watch.start("Add - TotalTime");
 		Model rdf = (Model) requestModel.getRequestMap().get("rdf");
 		ResponseParams responseParams = new ResponseParams();
 		Response response = new Response(Response.API_ID.CREATE, "OK", responseParams);
@@ -82,6 +83,7 @@ public class RegistryController {
 			responseParams.setStatus(Response.Status.UNSUCCESSFUL);
 			responseParams.setErrmsg(e.getMessage());
 		}
+		watch.stop("Add - TotalTime");
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 
@@ -120,7 +122,7 @@ public class RegistryController {
 		}
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
-	
+
 	@RequestMapping(value = "/search", method = RequestMethod.POST)
 	public ResponseEntity<Response> searchEntity(@RequestAttribute Request requestModel) {
 
@@ -154,7 +156,7 @@ public class RegistryController {
 		}
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
-	
+
 	@ResponseBody
 	@RequestMapping(value = "/update", method = RequestMethod.POST)
 	public ResponseEntity<Response> update(@RequestAttribute Request requestModel) {

--- a/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import com.google.common.collect.ImmutableList;
 import io.opensaber.pojos.OpenSaberInstrumentation;
 import io.opensaber.registry.exception.AuditFailedException;
@@ -51,7 +52,7 @@ public class RegistryDaoImpl implements RegistryDao {
 
     @Value("${registry.context.base}")
     private String registryContext;
-    
+
     @Value("${encryption.enabled}")
     private boolean encryptionEnabled;
 
@@ -67,8 +68,16 @@ public class RegistryDaoImpl implements RegistryDao {
     @Value("${authentication.enabled}")
     private boolean authenticationEnabled;
 
+    @Value("${database.persistence.enabled}")
+    private boolean persistenceEnabled;
+
     @Autowired
     private OpenSaberInstrumentation watch;
+
+    private Graph graphFromStore = null;
+    private GraphTraversalSource dbGraphTraversalSource = null;
+    private boolean isTransactionSupported = false;
+
 
     @Override
     public List getEntityList() {
@@ -76,81 +85,91 @@ public class RegistryDaoImpl implements RegistryDao {
         return null;
     }
 
- 
+    private void init() {
+        if (null == graphFromStore) {
+            graphFromStore = databaseProvider.getGraphStore();
+            dbGraphTraversalSource = graphFromStore.traversal();
+            isTransactionSupported = graphFromStore.features().graph().supportsTransactions();
+        }
+    }
+
+
     @Override
     public String addEntity(Graph entity, String label, String rootNodeLabel, String property) throws DuplicateRecordException, RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException {
-        logger.debug("RegistryDaoImpl : Database Provider features: \n" + databaseProvider.getGraphStore().features());
-        Graph graphFromStore = databaseProvider.getGraphStore();
-        GraphTraversalSource dbGraphTraversalSource = graphFromStore.traversal();
-        if (rootNodeLabel != null && property != null && !dbGraphTraversalSource.clone().V().hasLabel(rootNodeLabel).hasNext()) {
-            //closeGraph(graphFromStore);
+        if (!persistenceEnabled) {
+            return "R-Label";
+        }
+        init();
+
+        if (rootNodeLabel != null && property != null && !dbGraphTraversalSource.V().hasLabel(rootNodeLabel).hasNext()) {
             throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
-        } else if (dbGraphTraversalSource.clone().V().hasLabel(label).hasNext()) {
-            //closeGraph(graphFromStore);
+        } else if (dbGraphTraversalSource.V().hasLabel(label).hasNext()) {
             throw new DuplicateRecordException(Constants.DUPLICATE_RECORD_MESSAGE);
         }
 
         TinkerGraph graph = (TinkerGraph) entity;
         GraphTraversalSource traversal = graph.traversal();
-        if (graphFromStore.features().graph().supportsTransactions()) {
-            org.apache.tinkerpop.gremlin.structure.Transaction tx = graphFromStore.tx();
-            tx.onReadWrite(org.apache.tinkerpop.gremlin.structure.Transaction.READ_WRITE_BEHAVIOR.AUTO);
-            //label = createOrUpdateEntity(graph, label, "create");
-            watch.start("RegistryDaoImpl.addOrUpdateVerticesAndEdges");
-            label = addOrUpdateVerticesAndEdges(dbGraphTraversalSource, traversal, label, "create");
-            watch.stop("RegistryDaoImpl.addOrUpdateVerticesAndEdges");
-            if (rootNodeLabel != null && property != null) {
-                connectNodes(rootNodeLabel, label, property);
-            }
-            tx.commit();
-            logger.debug("RegistryDaoImpl : Entity added for transactional DB with rootNodeLabel : {},	label	:	{},	property	: 	{}", rootNodeLabel, label, property);
-        } else {
-            watch.start("RegistryDaoImpl.addOrUpdateVerticesAndEdges");
-            label = addOrUpdateVerticesAndEdges(dbGraphTraversalSource, traversal, label, "create");
-            watch.stop("RegistryDaoImpl.addOrUpdateVerticesAndEdges");
-            logger.debug("RegistryDaoImpl : Entity added for non-transactional DB with rootNodeLabel : {},	label	:	{},	property	: 	{}", rootNodeLabel, label, property);
-            if (rootNodeLabel != null && property != null) {
-                connectNodes(rootNodeLabel, label, property);
-            }
-        }
+        Transaction tx = startTransaction();
+
+        watch.start("RegistryDaoImpl.addOrUpdateVerticesAndEdges");
+        label = addOrUpdateVerticesAndEdges(dbGraphTraversalSource, traversal, label, "create");
+        watch.stop("RegistryDaoImpl.addOrUpdateVerticesAndEdges");
+        connectRootToEntity(dbGraphTraversalSource, rootNodeLabel, label, property);
+
+        commitTransaction(tx);
         logger.info("Successfully created entity with label " + label);
-        // closeGraph(graphFromStore);
         return label;
     }
 
-	/*
-	private void closeGraph(Graph graph) {
-		try {
-			graph.close();
-		} catch (Exception ex) {
-			logger.error("Exception when closing the database graph", ex);
-		}
-	}
-	*/
-
-    private void connectNodes(String rootLabel, String label, String property) throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException {
-        Graph graphFromStore = databaseProvider.getGraphStore();
-        GraphTraversalSource traversalSource = graphFromStore.traversal();
-
-        if (!traversalSource.clone().V().hasLabel(rootLabel).hasNext()) {
-            // closeGraph(graphFromStore);
-            throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
+    /**
+     * Starts a transaction if database supports it.
+     * @return
+     */
+    private Transaction startTransaction() {
+        Transaction tx = null;
+        if (isTransactionSupported) {
+            tx = graphFromStore.tx();
+            tx.onReadWrite(Transaction.READ_WRITE_BEHAVIOR.AUTO);
         }
-        if (!traversalSource.clone().V().hasLabel(label).hasNext()) {
-            // closeGraph(graphFromStore);
-            throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
-        }
-        connectRootToEntity(traversalSource, rootLabel, label, property);
-
+        return tx;
     }
 
+    /**
+     * Commits the changes on a transaction.
+     * @param tx - pass null for a no-op
+     */
+    private void commitTransaction(Transaction tx) {
+        if (isTransactionSupported && tx != null) {
+            tx.commit();
+        }
+    }
+
+
+    /**
+     * This method is used to connect the new child entity to the root. Adds an edge with the property
+     * between the root and entity.
+     * @param dbTraversalSource
+     * @param rootLabel
+     * @param label
+     * @param property
+     * @throws RecordNotFoundException
+     * @throws NoSuchElementException
+     * @throws EncryptionException
+     * @throws AuditFailedException
+     */
     private void connectRootToEntity(GraphTraversalSource dbTraversalSource, String rootLabel, String label, String property) throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException {
-        GraphTraversal<Vertex, Vertex> rootGts = dbTraversalSource.clone().V().hasLabel(rootLabel);
-        GraphTraversal<Vertex, Vertex> entityGts = dbTraversalSource.clone().V().hasLabel(label);
+        if (rootLabel == null || property == null) {
+            // no connections needed because the entity is itself a root.
+            return;
+        }
+
+        GraphTraversal<Vertex, Vertex> rootGts = dbTraversalSource.V().hasLabel(rootLabel);
+        GraphTraversal<Vertex, Vertex> entityGts = dbTraversalSource.V().hasLabel(label);
         Vertex rootVertex = rootGts.next();
         Vertex entityVertex = entityGts.next();
         rootVertex.addEdge(property, entityVertex);
-        if(auditEnabled) {
+
+        if (auditEnabled) {
             watch.start("RegistryDaoImpl.connectRootToEntity.auditRecord");
             AuditRecord record = appContext.getBean(AuditRecord.class);
             record
@@ -164,6 +183,29 @@ public class RegistryDaoImpl implements RegistryDao {
 
         logger.debug("RegistryDaoImpl : Audit record generated of connectRootToEntity for rootLabel : {}, label	:	{}, property :	{}", rootLabel, label, property);
     }
+
+
+    /**
+     *
+     * @param v
+     * @param existingVertex
+     * @param dbTraversalSource
+     * @param encDecPropertyBuilder - to be removed
+     * @param methodOrigin - to be removed
+     * @throws AuditFailedException
+     * @throws EncryptionException
+     * @throws RecordNotFoundException
+     */
+    //TODO: Refactor - remove methodOrigin and encDecPropertyBuilder
+    private void doAuditedUpdateVertex(Vertex v, Vertex existingVertex, GraphTraversalSource dbTraversalSource,
+                                       ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder, String methodOrigin)
+            throws AuditFailedException, EncryptionException, RecordNotFoundException {
+        setAuditInfo(v, false);
+        copyProperties(v, existingVertex, methodOrigin, encDecPropertyBuilder);
+        // watch.start("RegistryDaoImpl.addOrUpdateVertexAndEdge()");
+        addOrUpdateVertexAndEdge(v, existingVertex, dbTraversalSource, methodOrigin, encDecPropertyBuilder);
+    }
+
 
     /**
      * This method creates the root node of the entity if it already isn't present in the graph store
@@ -182,22 +224,21 @@ public class RegistryDaoImpl implements RegistryDao {
 
         GraphTraversal<Vertex, Vertex> gts = entitySource.clone().V().hasLabel(rootLabel);
         String label = rootLabel;
+        GraphTraversal<Vertex, Vertex> traversalRoot = dbTraversalSource.clone().V().hasLabel(rootLabel);
+
         while (gts.hasNext()) {
             Vertex v = gts.next();
-            GraphTraversal<Vertex, Vertex> hasLabel = dbTraversalSource.clone().V().hasLabel(rootLabel);
-            ImmutableTable.Builder<Vertex,Vertex,Map<String,Object>> encDecPropertyBuilder = ImmutableTable.<Vertex,Vertex,Map<String,Object>> builder();
+            ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder = ImmutableTable.<Vertex, Vertex, Map<String, Object>>builder();
 
-            if (hasLabel.hasNext()) {
+            if (traversalRoot.hasNext()) {
                 logger.info(String.format("Root node label {} already exists. Updating properties for the root node.", rootLabel));
-                Vertex existingVertex = hasLabel.next();
-                if(methodOrigin.equalsIgnoreCase("update") && existingVertex.property(registryContext+"@status").isPresent() && Constants.STATUS_INACTIVE.equals(existingVertex.value(registryContext + "@status"))){
+                Vertex existingVertex = traversalRoot.next();
+                if (methodOrigin.equalsIgnoreCase("update") &&
+                        existingVertex.property(registryContext + "@status").isPresent() &&
+                        Constants.STATUS_INACTIVE.equals(existingVertex.value(registryContext + "@status"))) {
                     throw new UnsupportedOperationException(Constants.ENTITY_NOT_FOUND);
                 }
-                setAuditInfo(v, false);
-                copyProperties(v, existingVertex, methodOrigin, encDecPropertyBuilder);
-                // watch.start("RegistryDaoImpl.addOrUpdateVertexAndEdge()");
-                addOrUpdateVertexAndEdge(v, existingVertex, dbTraversalSource, methodOrigin, encDecPropertyBuilder);
-                // watch.stop();
+                doAuditedUpdateVertex(v, existingVertex, dbTraversalSource, encDecPropertyBuilder, methodOrigin);
             } else {
                 if (methodOrigin.equalsIgnoreCase("update")) {
                     throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
@@ -205,22 +246,46 @@ public class RegistryDaoImpl implements RegistryDao {
                 label = generateBlankNodeLabel(rootLabel);
                 logger.info(String.format("Creating entity with label {}", rootLabel));
                 Vertex newVertex = dbTraversalSource.clone().addV(label).next();
-                setAuditInfo(v, true);
-                copyProperties(v, newVertex, methodOrigin, encDecPropertyBuilder);
-                // watch.start("RegistryDaoImpl.addOrUpdateVertexAndEdge()");
-                addOrUpdateVertexAndEdge(v, newVertex, dbTraversalSource, methodOrigin, encDecPropertyBuilder);
-                // watch.stop();
+                doAuditedUpdateVertex(v, newVertex, dbTraversalSource, encDecPropertyBuilder, methodOrigin);
             }
-            Table<Vertex,Vertex,Map<String,Object>>  encDecPropertyTable = encDecPropertyBuilder.build();
-            // watch.start("RegistryDaoImpl.updateEncryptedDecryptedProperties");
-            if(encDecPropertyTable.size() > 0){
+            Table<Vertex, Vertex, Map<String, Object>> encDecPropertyTable = encDecPropertyBuilder.build();
+            if (encDecPropertyTable.size() > 0) {
                 updateEncryptedDecryptedProperties(encDecPropertyTable, methodOrigin);
             }
-            // watch.stop();
-    }
+        }
 
         return label;
     }
+
+    private Edge addEdge(String methodOrigin, Vertex dbVertex, Vertex inVertex,
+                         String edgeLabel, Vertex newOrOldVertex, boolean isNew,
+                         ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder)
+            throws AuditFailedException, EncryptionException
+    {
+        // TODO: Refactor - remove the encDecPropertyBuilder param from here.
+        setAuditInfo(inVertex, isNew);
+
+        logger.info(String.format("Vertex with label {} already exists. Updating properties for the vertex", newOrOldVertex.label()));
+        copyProperties(inVertex, newOrOldVertex, methodOrigin, encDecPropertyBuilder);
+
+        Edge edgeAdded = dbVertex.addEdge(edgeLabel, newOrOldVertex);
+
+        if (auditEnabled) {
+            watch.start("RegistryDaoImpl.addOrUpdateVertexAndEdge.auditRecord");
+            AuditRecord record = appContext.getBean(AuditRecord.class);
+            record
+                    .subject(dbVertex.label())
+                    .predicate(edgeLabel)
+                    .oldObject(null)
+                    .newObject(newOrOldVertex.label())
+                    .record(databaseProvider);
+            watch.stop("RegistryDaoImpl.addOrUpdateVertexAndEdge.auditRecord");
+        }
+        logger.debug("RegistryDaoImpl : Audit record created with label : {}  ", dbVertex.label());
+        return edgeAdded;
+    }
+
+
 
     /**
      * This method takes the root node of an entity and then recursively creates or updates child vertices
@@ -232,188 +297,139 @@ public class RegistryDaoImpl implements RegistryDao {
      * @throws EncryptionException
      * @throws NoSuchElementException
      */
-    private void addOrUpdateVertexAndEdge(Vertex v, Vertex dbVertex, GraphTraversalSource dbGraph, String methodOrigin, ImmutableTable.Builder<Vertex,Vertex,Map<String,Object>> encDecPropertyBuilder)
-            throws NoSuchElementException, EncryptionException, AuditFailedException, RecordNotFoundException {
-        Iterator<Edge> edges = v.edges(Direction.OUT);
-        Iterator<Edge> edgeList = v.edges(Direction.OUT);
+    private void addOrUpdateVertexAndEdge(Vertex v, Vertex dbVertex, GraphTraversalSource dbGraph, String methodOrigin,
+                                          ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder)
+            throws NoSuchElementException, EncryptionException, AuditFailedException, RecordNotFoundException
+    {
+        Iterator<Edge> outEdgesOfV = v.edges(Direction.OUT);
         Stack<Pair<Vertex, Vertex>> parsedVertices = new Stack<>();
         List<Edge> dbEdgesForVertex = ImmutableList.copyOf(dbVertex.edges(Direction.OUT));
         List<Edge> edgeVertexMatchList = new ArrayList<Edge>();
 
-        while (edgeList.hasNext()) {
-            Edge e = edgeList.next();
-            Vertex ver = e.inVertex();
-            String edgeLabel = e.label();
+        outEdgesOfV.forEachRemaining( outEdge -> {
+            Vertex ver = outEdge.inVertex();
+            String edgeLabel = outEdge.label();
             Optional<Edge> edgeVertexAlreadyExists =
-                    dbEdgesForVertex.stream().filter(ed -> ed.label().equalsIgnoreCase(edgeLabel) && ed.inVertex().label().equalsIgnoreCase(ver.label())).findFirst();
+                    dbEdgesForVertex.stream().filter(ed -> ed.label().equalsIgnoreCase(edgeLabel) &&
+                            ed.inVertex().label().equalsIgnoreCase(ver.label())).findFirst();
             if (edgeVertexAlreadyExists.isPresent()) {
                 edgeVertexMatchList.add(edgeVertexAlreadyExists.get());
             }
-        }
+        });
+
         logger.debug("RegistryDaoImpl : Matching list size:" + edgeVertexMatchList.size());
 
-        while (edges.hasNext()) {
-            Edge e = edges.next();
-            Vertex ver = e.inVertex();
-            String edgeLabel = e.label();
+        // Reset before reuse.
+        outEdgesOfV = v.edges(Direction.OUT);
+        while (outEdgesOfV.hasNext()) {
+            Edge outEdge = outEdgesOfV.next();
+            Vertex ver = outEdge.inVertex();
+            String edgeLabel = outEdge.label();
             GraphTraversal<Vertex, Vertex> gt = dbGraph.clone().V().hasLabel(ver.label());
-            Optional<Edge> edgeAlreadyExists =
-                    dbEdgesForVertex.stream().filter(ed -> ed.label().equalsIgnoreCase(e.label())).findFirst();
-            Optional<Edge> edgeVertexAlreadyExists =
-                    dbEdgesForVertex.stream().filter(ed -> ed.label().equalsIgnoreCase(edgeLabel) && ed.inVertex().label().equalsIgnoreCase(ver.label())).findFirst();
-            verifyAndDelete(dbVertex, e, edgeAlreadyExists, edgeVertexMatchList, methodOrigin);
+
+            Optional<Edge> onlyEdgeExists =
+                    dbEdgesForVertex.stream().filter(ed -> ed.label().equalsIgnoreCase(edgeLabel)).findFirst();
+
+            boolean edgeVertexExists = edgeVertexMatchList.contains(edgeLabel);
+            boolean edgeExists = edgeVertexExists || onlyEdgeExists.isPresent();
+
+            if (methodOrigin.equalsIgnoreCase("update") && edgeExists
+                    || isSingleValued(outEdge)) {
+                doAuditedDelete(dbVertex, outEdge, edgeVertexMatchList);
+            }
+
+            Edge edgeAdded = null;
             if (gt.hasNext()) {
                 Vertex existingV = gt.next();
-                setAuditInfo(ver, false);
-                logger.info(String.format("Vertex with label {} already exists. Updating properties for the vertex", existingV.label()));
-                copyProperties(ver, existingV, methodOrigin, encDecPropertyBuilder);
-                if (!edgeVertexAlreadyExists.isPresent()) {
-                    Edge edgeAdded = dbVertex.addEdge(edgeLabel, existingV);
-                    edgeVertexMatchList.add(edgeAdded);
-                    if(auditEnabled) {
-                        watch.start("RegistryDaoImpl.addOrUpdateVertexAndEdge.auditRecord");
-                                AuditRecord record = appContext.getBean(AuditRecord.class);
-                        record
-                                .subject(dbVertex.label())
-                                .predicate(e.label())
-                                .oldObject(null)
-                                .newObject(existingV.label())
-                                .record(databaseProvider);
-                        watch.stop("RegistryDaoImpl.addOrUpdateVertexAndEdge.auditRecord");
-                    }
-                    logger.debug("RegistryDaoImpl : Audit record created for update/insert(upsert) with label : {}  ", dbVertex.label());
+                if (!edgeVertexExists) {
+                    edgeAdded = addEdge(methodOrigin, dbVertex, ver, edgeLabel, existingV, false, encDecPropertyBuilder);
+                    parsedVertices.push(new Pair<>(ver, existingV));
                 }
-                parsedVertices.push(new Pair<>(ver, existingV));
             } else {
                 if (methodOrigin.equalsIgnoreCase("update") && !isIRI(ver.label())) {
                     throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
                 }
+
                 String label = generateBlankNodeLabel(ver.label());
                 Vertex newV = dbGraph.addV(label).next();
-                setAuditInfo(ver, true);
-                logger.debug(String.format("RegistryDaoImpl : Adding vertex with label {} and adding properties", newV.label()));
-                copyProperties(ver, newV, methodOrigin, encDecPropertyBuilder);
-                logger.debug(String.format("RegistryDaoImpl : Adding edge with label {} for the vertex label {}.", e.label(), newV.label()));
+                logger.debug(String.format("RegistryDaoImpl : Adding edge with label {} for the vertex label {}.", outEdge.label(), newV.label()));
 
-                Edge edgeAdded = dbVertex.addEdge(edgeLabel, newV);
-                edgeVertexMatchList.add(edgeAdded);
-                if(auditEnabled) {
-                    AuditRecord record = appContext.getBean(AuditRecord.class);
-                    watch.start("RegistryDaoImpl.addOrUpdateVertexAndEdge.auditRecord");
-                    record
-                            .subject(dbVertex.label())
-                            .predicate(e.label())
-                            .oldObject(null)
-                            .newObject(newV.label())
-                            .record(databaseProvider);
-                    watch.stop("RegistryDaoImpl.addOrUpdateVertexAndEdge.auditRecord");
-                }
-                logger.debug("RegistryDaoImpl : Audit record created for update with label : {} ", dbVertex.label());
+                edgeAdded = addEdge(methodOrigin, dbVertex, ver, edgeLabel, newV, true, encDecPropertyBuilder);
                 parsedVertices.push(new Pair<>(ver, newV));
             }
+            edgeVertexMatchList.add(edgeAdded);
         }
+
+
         for (Pair<Vertex, Vertex> pv : parsedVertices) {
             addOrUpdateVertexAndEdge(pv.getValue0(), pv.getValue1(), dbGraph, methodOrigin, encDecPropertyBuilder);
         }
-
-
     }
-
-	/*private void deleteEdgeAndNode(Vertex dbVertex, Edge e, Optional<Edge> edgeAlreadyExists,List<Edge> edgeVertexMatchList, String methodOrigin)
-	 throws AuditFailedException, RecordNotFoundException{
-
-		Graph graphFromStore = databaseProvider.getGraphStore();
-    	GraphTraversalSource traversalSource = graphFromStore.traversal();
-    	GraphTraversal<Vertex, Vertex> dbHasLabel = traversalSource.clone().V().hasLabel(dbVertex.label());
-    	if (!dbHasLabel.hasNext()) {
-    		throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
-    	}
-    	boolean isSingleValued = schemaConfigurator.isSingleValued(e.label());
-    	if(dbHasLabel.hasNext()){
-    		Vertex dbSourceVertex = dbHasLabel.next();
-    		if (graphFromStore.features().graph().supportsTransactions()) {
-    			org.apache.tinkerpop.gremlin.structure.Transaction tx = graphFromStore.tx();
-    			tx.onReadWrite(org.apache.tinkerpop.gremlin.structure.Transaction.READ_WRITE_BEHAVIOR.AUTO);
-    			deleteEdgeAndNode(isSingleValued, dbSourceVertex, e, edgeAlreadyExists, edgeVertexMatchList, methodOrigin);
-    			tx.commit();
-    		}else{
-    			deleteEdgeAndNode(isSingleValued, dbSourceVertex, e, edgeAlreadyExists, edgeVertexMatchList, methodOrigin);
-    		}
-    	}
-	}*/
 
 
     /**
-     * This method checks if deletion of edge and node is required based on criteria and invokes deleteEdgeAndNode method
-     *
+     * Deletes the edge and node.
      * @param dbSourceVertex
      * @param e
-     * @param edgeAlreadyExists
      * @param edgeVertexMatchList
-     * @param methodOrigin
      * @throws AuditFailedException
      */
-    private void verifyAndDelete(Vertex dbSourceVertex, Edge e, Optional<Edge> edgeAlreadyExists, List<Edge> edgeVertexMatchList, String methodOrigin)
+    private void doAuditedDelete(Vertex dbSourceVertex, Edge e, List<Edge> edgeVertexMatchList)
             throws AuditFailedException {
-        boolean isSingleValued = schemaConfigurator.isSingleValued(e.label());
-        if ((edgeAlreadyExists.isPresent() && methodOrigin.equalsIgnoreCase("update")) || isSingleValued) {
-            Iterator<Edge> edgeIter = dbSourceVertex.edges(Direction.OUT, e.label());
-            while (edgeIter.hasNext()) {
-                Edge edge = edgeIter.next();
-                Optional<Edge> existingEdgeVertex =
-                        edgeVertexMatchList.stream().filter(ed -> ed.label().equalsIgnoreCase(edge.label()) && ed.inVertex().label().equalsIgnoreCase(edge.inVertex().label())).findFirst();
-                if (!existingEdgeVertex.isPresent()) {
-                    deleteEdgeAndNode(dbSourceVertex, edge, null);
+        // TODO: Refactor - can this be a remove than an iteration.
+        Iterator<Edge> edgeIter = dbSourceVertex.edges(Direction.OUT, e.label());
+        while (edgeIter.hasNext()) {
+            Edge edge = edgeIter.next();
+            Optional<Edge> existingEdgeVertex =
+                    edgeVertexMatchList.stream().filter(ed -> ed.label().equalsIgnoreCase(edge.label()) && ed.inVertex().label().equalsIgnoreCase(edge.inVertex().label())).findFirst();
+            if (!existingEdgeVertex.isPresent()) {
+                deleteEdgeAndNode(edge);
+
+                if (auditEnabled) {
+                    watch.start("RegistryDaoImpl.deleteEdgeAndNode.auditRecord");
+                    AuditRecord record = appContext.getBean(AuditRecord.class);
+                    String tailOfdbVertex = dbSourceVertex.label().substring(dbSourceVertex.label().lastIndexOf("/") + 1).trim();
+                    String auditVertexlabel = registryContext + tailOfdbVertex;
+                    record
+                            .subject(auditVertexlabel)
+                            .predicate(edge.label())
+                            .oldObject(edge.inVertex().label())
+                            .newObject(null)
+                            .record(databaseProvider);
+                    watch.stop("RegistryDaoImpl.deleteEdgeAndNode.auditRecord");
                 }
             }
         }
+    }
+
+    /**
+     * Returns true if the edge is single value, false otherwise.
+     * @param e
+     * @return
+     */
+    private boolean isSingleValued(Edge e) {
+        return schemaConfigurator.isSingleValued(e.label());
     }
 
     /**
      * This method deletes the edge and node if the node is an orphan node and if not, deletes only the edge
      *
-     * @param v
      * @param dbEdgeToBeRemoved
-     * @param dbVertexToBeDeleted
-     * @throws AuditFailedException
      */
-    private void deleteEdgeAndNode(Vertex v, Edge dbEdgeToBeRemoved, Vertex dbVertexToBeDeleted) throws AuditFailedException {
+    private void deleteEdgeAndNode(Edge dbEdgeToBeRemoved) {
         logger.info("Deleting edge and node of label : {}", dbEdgeToBeRemoved.label());
 
-
-        if (dbVertexToBeDeleted == null) {
-            dbVertexToBeDeleted = dbEdgeToBeRemoved.inVertex();
-        }
+        Vertex dbVertexToBeDeleted = dbEdgeToBeRemoved.inVertex();
         Iterator<Edge> inEdgeIter = dbVertexToBeDeleted.edges(Direction.IN);
         Iterator<Edge> outEdgeIter = dbVertexToBeDeleted.edges(Direction.OUT);
-        String edgeLabel = dbEdgeToBeRemoved.label();
-        String vertexLabel = dbVertexToBeDeleted.label();
-        if ((inEdgeIter.hasNext() && IteratorUtils.count(inEdgeIter) > 1) || outEdgeIter.hasNext()) {
-            logger.debug("RegistryDaoImpl : Deleting edge only for edge-label: {}", dbEdgeToBeRemoved.label());
-            dbEdgeToBeRemoved.remove();
-        } else {
-            logger.debug("RegistryDaoImpl : Deleting edge and node for edge-label: {} and vertex-label : {}", dbEdgeToBeRemoved.label(), dbVertexToBeDeleted.label());
+
+        if (!(inEdgeIter.hasNext() && IteratorUtils.count(inEdgeIter) > 1) || outEdgeIter.hasNext()) {
             dbVertexToBeDeleted.remove();
-            dbEdgeToBeRemoved.remove();
-        }
-        if(auditEnabled) {
-            watch.start("RegistryDaoImpl.deleteEdgeAndNode.auditRecord");
-            AuditRecord record = appContext.getBean(AuditRecord.class);
-            String tailOfdbVertex = v.label().substring(v.label().lastIndexOf("/") + 1).trim();
-            String auditVertexlabel = registryContext + tailOfdbVertex;
-            record
-                    .subject(auditVertexlabel)
-                    .predicate(edgeLabel)
-                    .oldObject(vertexLabel)
-                    .newObject(null)
-                    .record(databaseProvider);
-            watch.stop("RegistryDaoImpl.deleteEdgeAndNode.auditRecord");
         }
 
+        dbEdgeToBeRemoved.remove();
         logger.debug("RegistryDaoImpl : Audit record created for deletion of vertex : {}", dbVertexToBeDeleted);
-
     }
-
 
     /**
      * Blank nodes are no longer supported. If the input data has a blank node, which is identified
@@ -429,6 +445,12 @@ public class RegistryDaoImpl implements RegistryDao {
         return label;
     }
 
+    /**
+     * Takes in a label and returns true if it of type http
+     * Allows local URLs too.
+     * @param label
+     * @return
+     */
     private boolean isIRI(String label) {
         UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
         if (urlValidator.isValid(label)) {
@@ -437,6 +459,10 @@ public class RegistryDaoImpl implements RegistryDao {
         return false;
     }
 
+    /**
+     * Generates a 4 part UUID.
+     * @return
+     */
     public static String generateRandomUUID() {
         return UUID.randomUUID().toString();
     }
@@ -444,33 +470,21 @@ public class RegistryDaoImpl implements RegistryDao {
     @Override
     public boolean updateEntity(Graph entityForUpdate, String rootNodeLabel, String methodOrigin)
             throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException {
-        Graph graphFromStore = databaseProvider.getGraphStore();
-        GraphTraversalSource dbGraphTraversalSource = graphFromStore.traversal();
+        init();
+
         TinkerGraph graphForUpdate = (TinkerGraph) entityForUpdate;
         GraphTraversalSource traversal = graphForUpdate.traversal();
         // Check if the root node being updated exists in the database
         GraphTraversal<Vertex, Vertex> hasRootLabel = dbGraphTraversalSource.clone().V().hasLabel(rootNodeLabel);
         if (!hasRootLabel.hasNext()) {
-            // closeGraph(graphFromStore);
             throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
         } else {
-            if (graphFromStore.features().graph().supportsTransactions()) {
-                org.apache.tinkerpop.gremlin.structure.Transaction tx = graphFromStore.tx();
-                tx.onReadWrite(org.apache.tinkerpop.gremlin.structure.Transaction.READ_WRITE_BEHAVIOR.AUTO);
-                //createOrUpdateEntity(graphForUpdate, rootNodeLabel, methodOrigin);
-                watch.start("RegistryDaoImpl.updateEntity");
-                addOrUpdateVerticesAndEdges(dbGraphTraversalSource, traversal, rootNodeLabel, methodOrigin);
-                tx.commit();
-                watch.stop("RegistryDaoImpl.updateEntity");
-                logger.debug("RegistryDaoImpl : Entity Updated for transactional DB with rootNodeLabel : {}", rootNodeLabel);
-            } else {
-                watch.start("RegistryDaoImpl.updateEntity");
-                addOrUpdateVerticesAndEdges(dbGraphTraversalSource, traversal, rootNodeLabel, methodOrigin);
-                watch.stop("RegistryDaoImpl.updateEntity");
-                logger.debug("RegistryDaoImpl : Entity Updated for non-transactional DB with rootNodeLabel : {}", rootNodeLabel);
-                //createOrUpdateEntity(graphForUpdate, rootNodeLabel, methodOrigin);
-            }
-            //closeGraph(graphFromStore);
+            Transaction tx = startTransaction();
+            watch.start("RegistryDaoImpl.updateEntity");
+            addOrUpdateVerticesAndEdges(dbGraphTraversalSource, traversal, rootNodeLabel, methodOrigin);
+            watch.stop("RegistryDaoImpl.updateEntity");
+            logger.debug("RegistryDaoImpl : Entity Updated with rootNodeLabel : {}", rootNodeLabel);
+            commitTransaction(tx);
         }
         return false;
     }
@@ -478,9 +492,8 @@ public class RegistryDaoImpl implements RegistryDao {
 
     @Override
     public Graph getEntityById(String label) throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException {
-        Graph graphFromStore = databaseProvider.getGraphStore();
-        GraphTraversalSource traversalSource = graphFromStore.traversal();
-        GraphTraversal<Vertex, Vertex> hasLabel = traversalSource.clone().V().hasLabel(label);
+        init();
+        GraphTraversal<Vertex, Vertex> hasLabel = dbGraphTraversalSource.clone().V().hasLabel(label);
         ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder = ImmutableTable.<Vertex, Vertex, Map<String, Object>>builder();
         Graph parsedGraph = TinkerGraph.open();
         if (!hasLabel.hasNext()) {
@@ -489,7 +502,7 @@ public class RegistryDaoImpl implements RegistryDao {
         } else {
             logger.info("Record exists for label : {}", label);
             Vertex subject = hasLabel.next();
-            if(subject.property(registryContext+"@status").isPresent() && Constants.STATUS_INACTIVE.equals(subject.value(registryContext + "@status"))){
+            if (subject.property(registryContext + "@status").isPresent() && Constants.STATUS_INACTIVE.equals(subject.value(registryContext + "@status"))) {
                 throw new UnsupportedOperationException(Constants.READ_ON_DELETE_ENTITY_NOT_SUPPORTED);
             }
             Vertex newSubject = parsedGraph.addVertex(subject.label());
@@ -509,37 +522,29 @@ public class RegistryDaoImpl implements RegistryDao {
 
     @Override
     public boolean deleteEntityById(String idLabel) throws RecordNotFoundException {
-        boolean isEntityDeleted= false;
-        Graph graphFromStore = databaseProvider.getGraphStore();
-        GraphTraversalSource traversalSource = graphFromStore.traversal();
+        boolean isEntityDeleted = false;
+        init();
+        GraphTraversalSource traversalSource = dbGraphTraversalSource;
         GraphTraversal<Vertex, Vertex> hasLabel = traversalSource.clone().V().hasLabel(idLabel);
-        //Graph parsedGraph = TinkerGraph.open();
+
         if (!hasLabel.hasNext()) {
             logger.info("Record not found  for label : {}", idLabel);
             throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
         } else {
-            if (graphFromStore.features().graph().supportsTransactions()) {
-                org.apache.tinkerpop.gremlin.structure.Transaction tx = graphFromStore.tx();
-                tx.onReadWrite(org.apache.tinkerpop.gremlin.structure.Transaction.READ_WRITE_BEHAVIOR.AUTO);
+                Transaction tx = startTransaction();
 
                 watch.start("RegistryDaoImpl.deleteEntityById");
                 logger.debug("Record exists for label : {}", idLabel);
                 Vertex s = hasLabel.next();
-                if(s.property(registryContext+"@status").isPresent() && Constants.STATUS_INACTIVE.equals(s.value(registryContext+"@status"))){
+                if (s.property(registryContext + "@status").isPresent() && Constants.STATUS_INACTIVE.equals(s.value(registryContext + "@status"))) {
                     throw new UnsupportedOperationException(Constants.DELETE_UNSUPPORTED_OPERATION_ON_ENTITY);
                 } else {
                     isEntityDeleted = deleteVertexWithInEdge(s);
                 }
 
-                tx.commit();
+                commitTransaction(tx);
                 watch.stop("RegistryDaoImpl.deleteEntityById");
                 logger.debug("RegistryDaoImpl : Entity deleted for transactional DB with rootNodeLabel : {}", idLabel);
-            } else {
-                logger.info("Record exists for label : {}", idLabel);
-                Vertex s = hasLabel.next();
-                isEntityDeleted = deleteVertexWithInEdge(s);
-            }
-
         }
         return isEntityDeleted;
     }
@@ -549,46 +554,24 @@ public class RegistryDaoImpl implements RegistryDao {
         Edge edge;
         Stack<Vertex> vStack = new Stack<Vertex>();
         Iterator<Edge> inEdgeIter = s.edges(Direction.IN);
-        while(inEdgeIter.hasNext()) {
-                edge = inEdgeIter.next();
-                Vertex o = edge.outVertex();
-                if (!vStack.contains(o)) {
-                    vStack.push(o);
-                    if(o.property(registryContext+"@status").isPresent() && Constants.STATUS_ACTIVE.equals(o.value(registryContext + "@status"))) {
-                        return false;
-                    }
-                }
-        }
-        s.property(registryContext+"@status",Constants.STATUS_INACTIVE);
-        return true;
-        /*Stack<Vertex> vStack = new Stack<Vertex>();
-        while (edgeIter.hasNext()) {
-            edge = edgeIter.next();
-            Vertex o = edge.inVertex();
-            if(!vStack.contains(o)) {
+        while (inEdgeIter.hasNext()) {
+            edge = inEdgeIter.next();
+            Vertex o = edge.outVertex();
+            if (!vStack.contains(o)) {
                 vStack.push(o);
+                if (o.property(registryContext + "@status").isPresent() && Constants.STATUS_ACTIVE.equals(o.value(registryContext + "@status"))) {
+                    return false;
+                }
             }
-            //edge.remove();
         }
-        //if vertex has no incoming edges delete the node
-        Iterator<Edge> inEdgeIter = s.edges(Direction.IN);
-        inEdgeIter.
-        if (!(inEdgeIter.hasNext() && IteratorUtils.count(inEdgeIter) > 1)) {
-            s.property(registryContext+"@status",Constants.STATUS_INACTIVE);
-        }*/
-        /*Iterator<Vertex> vIterator = vStack.iterator();
-
-        while(vIterator.hasNext()){
-            s = vIterator.next();
-            deleteVertexWithOUTEdge(s);
-        }*/
-
+        s.property(registryContext + "@status", Constants.STATUS_INACTIVE);
+        return true;
     }
 
     private void copyProperties(Vertex subject, Vertex newSubject, String methodOrigin, ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder)
             throws NoSuchElementException, EncryptionException, AuditFailedException {
         HashMap<String, HashMap<String, String>> propertyMetaPropertyMap = new HashMap<String, HashMap<String, String>>();
-        if(methodOrigin.equalsIgnoreCase("create")) {
+        if (methodOrigin.equalsIgnoreCase("create")) {
             subject.property(registryContext + "@status", Constants.STATUS_ACTIVE);
         }
         Iterator<VertexProperty<Object>> iter = subject.properties();
@@ -602,8 +585,8 @@ public class RegistryDaoImpl implements RegistryDao {
             if ((methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")) && existingEncyptedPropertyKey) {
                 property.remove();
             }
-            if ((methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")) && schemaConfigurator.isPrivate(property.key()) 
-            		&& encryptionEnabled && !existingEncyptedPropertyKey) {
+            if ((methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")) && schemaConfigurator.isPrivate(property.key())
+                    && encryptionEnabled && !existingEncyptedPropertyKey) {
                 propertyMap.put(property.key(), property.value());
             } else if (methodOrigin.equalsIgnoreCase("read") && schemaConfigurator.isEncrypted(tailOfPropertyKey) && encryptionEnabled) {
                 propertyMap.put(property.key(), property.value());
@@ -705,8 +688,8 @@ public class RegistryDaoImpl implements RegistryDao {
             Iterator _mpmapIter = _mpmap.entrySet().iterator();
             while (_mpmapIter.hasNext()) {
                 Map.Entry _pair = (Map.Entry) _mpmapIter.next();
-            logger.info("META PROPERTY <- " + _pair.getKey() + "|" + _pair.getValue() + "|" + newSubject.property(pair.getKey().toString()).isPresent());
-            newSubject.property(pair.getKey().toString()).property(_pair.getKey().toString(), _pair.getValue().toString());
+                logger.info("META PROPERTY <- " + _pair.getKey() + "|" + _pair.getValue() + "|" + newSubject.property(pair.getKey().toString()).isPresent());
+                newSubject.property(pair.getKey().toString()).property(_pair.getKey().toString(), _pair.getValue().toString());
             }
         }
     }
@@ -751,64 +734,29 @@ public class RegistryDaoImpl implements RegistryDao {
         }
     }
 
-    /*@Override
-    public boolean deleteEntity (Graph entity, String rootLabel) throws RecordNotFoundException,AuditFailedException {
-    	Graph graphFromStore = databaseProvider.getGraphStore();
-    	GraphTraversalSource traversalSource = graphFromStore.traversal();
-    	GraphTraversal<Vertex, Vertex> dbHasLabel = traversalSource.clone().V().hasLabel(rootLabel);
-    	if (!dbHasLabel.hasNext()) {
-    		throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
-    	}
-
-    	GraphTraversal<Vertex, Vertex> hasNestedLabel = traversalSource.clone().V().hasLabel(labelToBeDeleted);
-    	if (!hasNestedLabel.hasNext()) {
-			logger.info("Record not found to be deleted !");
-    		throw new RecordNotFoundException(Constants.ENTITY_NOT_FOUND);
-    	}
-    	TinkerGraph graph = (TinkerGraph) entity;
-		GraphTraversalSource traversal = graph.traversal();
-    	GraphTraversal<Vertex, Vertex> gts = traversal.clone().V().hasLabel(rootLabel);
-
-    	if (graphFromStore.features().graph().supportsTransactions()) {
-    		org.apache.tinkerpop.gremlin.structure.Transaction tx;
-    		tx = graphFromStore.tx();
-    		tx.onReadWrite(org.apache.tinkerpop.gremlin.structure.Transaction.READ_WRITE_BEHAVIOR.AUTO);
-    		deleteEdgeAndNode(dbHasLabel.next(), gts);
-    		tx.commit();
-    		tx.close();
-    		logger.info("Entity for {} deleted !", rootLabel);
-    		return true;
-    	} else {
-    		deleteEdgeAndNode(dbHasLabel.next(), gts);
-    		logger.info("Entity for {} deleted !", rootLabel);
-    	}
-
-    	return false;
-    }*/
-
-	private void extractGraphFromVertex(Graph parsedGraph,Vertex parsedGraphSubject,Vertex s, ImmutableTable.Builder<Vertex,Vertex,Map<String,Object>> encDecPropertyBuilder)
-			throws NoSuchElementException, EncryptionException, AuditFailedException {
-		Iterator<Edge> edgeIter = s.edges(Direction.OUT);
-		Edge edge;
-		Stack<Vertex> vStack = new Stack<Vertex>();
-		Stack<Vertex> parsedVStack = new Stack<Vertex>();
-		while(edgeIter.hasNext()){
-			edge = edgeIter.next();
-			Vertex o = edge.inVertex();
-			Vertex newo = parsedGraph.addVertex(o.label());
-			copyProperties(o, newo,"read", encDecPropertyBuilder);
-			parsedGraphSubject.addEdge(edge.label(), newo);
-			vStack.push(o);
-			parsedVStack.push(newo);
-		}
-		Iterator<Vertex> vIterator = vStack.iterator();
-		Iterator<Vertex> parsedVIterator = parsedVStack.iterator();
-		while(vIterator.hasNext()){
-			s = vIterator.next();
-			parsedGraphSubject = parsedVIterator.next();
-			extractGraphFromVertex(parsedGraph,parsedGraphSubject,s, encDecPropertyBuilder);
-		}
-	}
+    private void extractGraphFromVertex(Graph parsedGraph, Vertex parsedGraphSubject, Vertex s, ImmutableTable.Builder<Vertex, Vertex, Map<String, Object>> encDecPropertyBuilder)
+            throws NoSuchElementException, EncryptionException, AuditFailedException {
+        Iterator<Edge> edgeIter = s.edges(Direction.OUT);
+        Edge edge;
+        Stack<Vertex> vStack = new Stack<Vertex>();
+        Stack<Vertex> parsedVStack = new Stack<Vertex>();
+        while (edgeIter.hasNext()) {
+            edge = edgeIter.next();
+            Vertex o = edge.inVertex();
+            Vertex newo = parsedGraph.addVertex(o.label());
+            copyProperties(o, newo, "read", encDecPropertyBuilder);
+            parsedGraphSubject.addEdge(edge.label(), newo);
+            vStack.push(o);
+            parsedVStack.push(newo);
+        }
+        Iterator<Vertex> vIterator = vStack.iterator();
+        Iterator<Vertex> parsedVIterator = parsedVStack.iterator();
+        while (vIterator.hasNext()) {
+            s = vIterator.next();
+            parsedGraphSubject = parsedVIterator.next();
+            extractGraphFromVertex(parsedGraph, parsedGraphSubject, s, encDecPropertyBuilder);
+        }
+    }
 
     private void updateEncryptedDecryptedProperties(Table<Vertex, Vertex, Map<String, Object>> encDecPropertyTable, String methodOrigin) throws EncryptionException, AuditFailedException {
         Map<String, Object> propertyMap = new HashMap<>();
@@ -827,6 +775,7 @@ public class RegistryDaoImpl implements RegistryDao {
         if (methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")) {
             encDecMap = encryptionService.encrypt(propertyMap);
         } else {
+            logger.debug("FATAL: why would a non-create non-update come here?");
             encDecMap = encryptionService.decrypt(propertyMap);
         }
 
@@ -841,79 +790,82 @@ public class RegistryDaoImpl implements RegistryDao {
     }
 
 
-	private Map<String,Object> updateEncDecListMap(Map<String, Object> listPropertyMap, String methodOrigin) throws EncryptionException{
-		Map<String,Object> encDecListPropertyMap = new HashMap<String,Object>();
-			for(Map.Entry<String, Object> entry: listPropertyMap.entrySet()){
-				String k = entry.getKey();
-				Object v = entry.getValue();
-				List values = (List)v;
-				List encValues = new ArrayList();
-				for(Object listV : values){
-					String encDecValue = null;
-					if(methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")){
-						encDecValue = encryptionService.encrypt(listV);
-					}else{
-						encDecValue = encryptionService.decrypt(listV);
-					}
-					encValues.add(encDecValue);
-				}
-				encDecListPropertyMap.put(k, encValues);
-			}
-		return encDecListPropertyMap;
-	}
+    private Map<String, Object> updateEncDecListMap(Map<String, Object> listPropertyMap, String methodOrigin) throws EncryptionException {
+        Map<String, Object> encDecListPropertyMap = new HashMap<String, Object>();
+        for (Map.Entry<String, Object> entry : listPropertyMap.entrySet()) {
+            String k = entry.getKey();
+            Object v = entry.getValue();
+            List values = (List) v;
+            List encValues = new ArrayList();
+            for (Object listV : values) {
+                String encDecValue = null;
+                if (methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")) {
+                    encDecValue = encryptionService.encrypt(listV);
+                } else {
+                    encDecValue = encryptionService.decrypt(listV);
+                }
+                encValues.add(encDecValue);
+            }
+            encDecListPropertyMap.put(k, encValues);
+        }
+        return encDecListPropertyMap;
+    }
 
 
-	private void setEncDecMap(Map<String,Object> encryptedMap, Table<Vertex,Vertex,Map<String,Object>> encDecPropertyTable){
-			for(Map.Entry<String, Object> entry : encryptedMap.entrySet()){
-				encDecPropertyTable.values().forEach(map -> { if(map.containsKey(entry.getKey())){
-					map.put(entry.getKey(), entry.getValue());
-				}
-				});
-			}
-	}
+    private void setEncDecMap(Map<String, Object> encryptedMap, Table<Vertex, Vertex, Map<String, Object>> encDecPropertyTable) {
+        for (Map.Entry<String, Object> entry : encryptedMap.entrySet()) {
+            encDecPropertyTable.values().forEach(map -> {
+                if (map.containsKey(entry.getKey())) {
+                    map.put(entry.getKey(), entry.getValue());
+                }
+            });
+        }
+    }
 
-	private void setEncryptedDecryptedProperty(Table<Vertex,Vertex,Map<String,Object>> encDecPropertyTable, String methodOrigin) throws AuditFailedException{
+    private void setEncryptedDecryptedProperty(Table<Vertex, Vertex, Map<String, Object>> encDecPropertyTable, String methodOrigin) throws AuditFailedException {
 
-		for(Table.Cell<Vertex,Vertex,Map<String,Object>> cell: encDecPropertyTable.cellSet()){
-			Vertex subject = cell.getRowKey();
-			Vertex newSubject = cell.getColumnKey();
-			for(Map.Entry<String, Object> entry : cell.getValue().entrySet()){
-				Object entryValue = entry.getValue();
-				String entryKey = entry.getKey();
-				String tailOfPropertyKey = entryKey.substring(entryKey.lastIndexOf("/") + 1).trim();
-				String newKey = null;
-				if (methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")){
-					newKey = entryKey.replace(tailOfPropertyKey, "encrypted" + tailOfPropertyKey);
-					setProperty(newSubject, newKey, entryValue, methodOrigin);
-					VertexProperty property = subject.property(entryKey);
-					setMetaProperty(subject, newSubject, property, methodOrigin);
-				} else if(methodOrigin.equalsIgnoreCase("read")){
-					newKey = entryKey.replace(tailOfPropertyKey, tailOfPropertyKey.substring(9));
-					Iterator<Property<Object>> propIter = newSubject.property(newKey).properties();
-					setProperty(newSubject, newKey, entryValue, methodOrigin);
-					while(propIter.hasNext()){
-						Property<Object> propertyObj = propIter.next();
-						newSubject.property(newKey).property(propertyObj.key(), propertyObj.value());
-					}
-				}
+        for (Table.Cell<Vertex, Vertex, Map<String, Object>> cell : encDecPropertyTable.cellSet()) {
+            Vertex subject = cell.getRowKey();
+            Vertex newSubject = cell.getColumnKey();
+            for (Map.Entry<String, Object> entry : cell.getValue().entrySet()) {
+                Object entryValue = entry.getValue();
+                String entryKey = entry.getKey();
+                String tailOfPropertyKey = entryKey.substring(entryKey.lastIndexOf("/") + 1).trim();
+                String newKey = null;
+                if (methodOrigin.equalsIgnoreCase("create") || methodOrigin.equalsIgnoreCase("update")) {
+                    newKey = entryKey.replace(tailOfPropertyKey, "encrypted" + tailOfPropertyKey);
+                    setProperty(newSubject, newKey, entryValue, methodOrigin);
+                    VertexProperty property = subject.property(entryKey);
+                    setMetaProperty(subject, newSubject, property, methodOrigin);
+                } else if (methodOrigin.equalsIgnoreCase("read")) {
+                    newKey = entryKey.replace(tailOfPropertyKey, tailOfPropertyKey.substring(9));
+                    Iterator<Property<Object>> propIter = newSubject.property(newKey).properties();
+                    setProperty(newSubject, newKey, entryValue, methodOrigin);
+                    while (propIter.hasNext()) {
+                        Property<Object> propertyObj = propIter.next();
+                        newSubject.property(newKey).property(propertyObj.key(), propertyObj.value());
+                    }
+                }
 
-			}
-		}
-	}
+            }
+        }
+    }
 
 
-	public void setAuditInfo(Vertex v, boolean isNew){
-		if(authenticationEnabled){
-			String userId = ((AuthInfo) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getSub();
-			long timestamp = new Date().getTime();
-			if(isNew){
-				v.property(registryContext+Constants.AuditProperties.createdBy.name(),userId);
-				v.property(registryContext+Constants.AuditProperties.createdAt.name(),timestamp);
-			}
-			v.property(registryContext+Constants.AuditProperties.lastUpdatedBy.name(),userId);
-			v.property(registryContext+Constants.AuditProperties.lastUpdatedAt.name(),timestamp);
-		}
-	}
+    public void setAuditInfo(Vertex v, boolean isNew) {
+        if (authenticationEnabled) {
+            String userId = ((AuthInfo) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getSub();
+            long timestamp = new Date().getTime();
+            if (isNew) {
+                v.property(registryContext + Constants.AuditProperties.createdBy.name(), userId);
+                v.property(registryContext + Constants.AuditProperties.createdAt.name(), timestamp);
+            }
+            v.property(registryContext + Constants.AuditProperties.lastUpdatedBy.name(), userId);
+            v.property(registryContext + Constants.AuditProperties.lastUpdatedAt.name(), timestamp);
+        } else {
+            logger.debug("AuthenticationEnabled: false - So not adding audit information.");
+        }
+    }
 
 }
 

--- a/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
@@ -507,7 +507,7 @@ public class RegistryDaoImpl implements RegistryDao {
             Vertex newSubject = parsedGraph.addVertex(subject.label());
             copyProperties(subject, newSubject, Constants.READ_METHOD_ORIGIN, encDecPropertyBuilder);
             watch.start("RegistryDaoImpl.getEntityById.extractGraphFromVertex");
-            extractGraphFromVertex(parsedGraph, newSubject, subject, encDecPropertyBuilder, Constants.READ_METHOD_ORIGIN);
+            extractGraphFromVertex(parsedGraph, newSubject, subject, encDecPropertyBuilder);
             watch.stop("RegistryDaoImpl.getEntityById.extractGraphFromVertex");
             Table<Vertex, Vertex, Map<String, Object>> encDecPropertyTable = encDecPropertyBuilder.build();
             if (encDecPropertyTable.size() > 0) {
@@ -528,7 +528,7 @@ public class RegistryDaoImpl implements RegistryDao {
     	copyProperties(vertex, newSubject, Constants.SEARCH_METHOD_ORIGIN, null);
     	watch.stop("RegistryDaoImpl.getEntityByVertex.copyProperties");
     	watch.start("RegistryDaoImpl.getEntityByVertex.extractGraphFromVertex");
-    	extractGraphFromVertex(parsedGraph, newSubject, vertex, null, Constants.SEARCH_METHOD_ORIGIN);
+    	extractGraphFromVertex(parsedGraph, newSubject, vertex, null);
     	watch.stop("RegistryDaoImpl.getEntityByVertex.extractGraphFromVertex");
     	return parsedGraph;
     }

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -29,6 +29,8 @@ config:
 
 database:
   provider: ${database_provider:NEO4J}
+  persistence
+    enabled: ${database_persistence_enabled:true}
   neo4j:
     embedded: ${database_embedded:true}
     # Set an environment variable NEO4J_HOST if running Neo4J as a standalone host
@@ -125,6 +127,8 @@ config:
 
 database:
   provider: TINKERGRAPH
+  persistence:
+    enabled: ${database_persistence_enabled:true}
 
 # RDF Validation Config
 validations:

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -29,7 +29,7 @@ config:
 
 database:
   provider: ${database_provider:NEO4J}
-  persistence
+  persistence:
     enabled: ${database_persistence_enabled:true}
   neo4j:
     embedded: ${database_embedded:true}


### PR DESCRIPTION
Summary of changes:
1. Created an init method to setup some common static, reusable vars
2. Created a startTransaction, commitTransaction methods that will take care of starting and committing a transaction, if the underlying database supports it.
3. Most places the if-else code blocks were doing a similar thing with minor variation in the params - removed such occurrences.
4. Left some TODO-Refactor in here for my reference.

Future work:
- get rid of encryption and move it up
- methodOrigin should be removed
- align the interface to graphengine interface

Testing done (using postman):
1. Invoked add record (of type teacher) -> Added record success.
2. Deleted this record -> Delete success (can't issue a GET and retrieve)
3. Repeat 1 and Added an entity (obj) -> Added success (can issue a GET and retrieve the updated info).

Most of my initial commits failed due to missing application.yml.sample changes, unit-test case failure. I've learnt now, thanks for your patience.