### PR TITLE
Issue #OS-47 Add ability to include signatures optionally

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -1,10 +1,12 @@
 package io.opensaber.registry.controller;
 
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import io.opensaber.pojos.*;
+import io.opensaber.registry.exception.*;
 import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.service.RegistryService;
+import io.opensaber.registry.service.SearchService;
 import io.opensaber.registry.util.JSONUtil;
 import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
@@ -13,23 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
+import org.springframework.web.bind.annotation.*;
 
-import io.opensaber.registry.exception.AuditFailedException;
-import io.opensaber.registry.exception.DuplicateRecordException;
-import io.opensaber.registry.exception.EntityCreationException;
-import io.opensaber.registry.exception.RecordNotFoundException;
-import io.opensaber.registry.exception.TypeNotProvidedException;
-import io.opensaber.registry.service.RegistryService;
-import io.opensaber.registry.service.SearchService;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 public class RegistryController {
@@ -86,7 +76,8 @@ public class RegistryController {
 	}
 
 	@RequestMapping(value = "/read/{id}", method = RequestMethod.GET)
-	public ResponseEntity<Response> readEntity(@PathVariable("id") String id) {
+    public ResponseEntity<Response> readEntity(@PathVariable("id") String id,
+                                               @RequestParam(required = false) boolean includeSignatures) {
 
 		String entityId = registryContext + id;
 		ResponseParams responseParams = new ResponseParams();
@@ -94,7 +85,7 @@ public class RegistryController {
 
 		try {
 			watch.start("RegistryController.readEntity");
-			org.eclipse.rdf4j.model.Model entityModel = registryService.getEntityById(entityId);
+            org.eclipse.rdf4j.model.Model entityModel = registryService.getEntityById(entityId, includeSignatures);
 			logger.debug("FETCHED: " + entityModel);
 			String jenaJSON = registryService.frameEntity(entityModel);
 			response.setResult(gson.fromJson(jenaJSON, mapType));

--- a/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDao.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDao.java
@@ -1,31 +1,25 @@
 package io.opensaber.registry.dao;
 
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import io.opensaber.registry.exception.AuditFailedException;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-
 import io.opensaber.registry.exception.DuplicateRecordException;
 import io.opensaber.registry.exception.EncryptionException;
 import io.opensaber.registry.exception.RecordNotFoundException;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 public interface RegistryDao {
 
 	public List getEntityList();
 
-//	public String addEntity(Graph entity, String label) throws DuplicateRecordException, EncryptionException, AuditFailedException, RecordNotFoundException;
-	
 	public String addEntity(Graph entity, String label, String rootNodeLabel, String property) throws DuplicateRecordException, RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException;
 
 	public boolean updateEntity(Graph entityForUpdate, String rootNodeLabel, String methodOrigin)
 			throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException;
 
-	//public boolean deleteEntity (Graph entity, String rootLabel) throws RecordNotFoundException,AuditFailedException;
-
-	public Graph getEntityById(String label) throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException;
+	public Graph getEntityById(String label, boolean includeSignatures) throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException;
 	
 	public Graph getEntityByVertex(Vertex vertex) throws RecordNotFoundException, NoSuchElementException, EncryptionException, AuditFailedException;
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/RegistryService.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/RegistryService.java
@@ -1,12 +1,12 @@
 package io.opensaber.registry.service;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.NoSuchElementException;
-
 import io.opensaber.pojos.HealthCheckResponse;
 import io.opensaber.registry.exception.*;
 import org.apache.jena.rdf.model.Model;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 public interface RegistryService {
 	
@@ -18,9 +18,9 @@ public interface RegistryService {
 	EncryptionException, AuditFailedException, MultipleEntityException, RecordNotFoundException;
 	
 	public boolean updateEntity(Model entity) throws RecordNotFoundException, EntityCreationException, EncryptionException, AuditFailedException, MultipleEntityException;
-	
-	public org.eclipse.rdf4j.model.Model getEntityById(String id) throws RecordNotFoundException, EncryptionException, AuditFailedException;
-	
+
+	public org.eclipse.rdf4j.model.Model getEntityById(String id, boolean withSignatures) throws RecordNotFoundException, EncryptionException, AuditFailedException;
+
 	//public boolean deleteEntity(Model rdfModel) throws AuditFailedException, RecordNotFoundException;
 
 	public HealthCheckResponse health() throws Exception;

--- a/java/registry/src/main/java/io/opensaber/registry/service/RegistryService.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/RegistryService.java
@@ -19,7 +19,7 @@ public interface RegistryService {
 	
 	public boolean updateEntity(Model entity) throws RecordNotFoundException, EntityCreationException, EncryptionException, AuditFailedException, MultipleEntityException;
 
-	public org.eclipse.rdf4j.model.Model getEntityById(String id, boolean withSignatures) throws RecordNotFoundException, EncryptionException, AuditFailedException;
+	public org.eclipse.rdf4j.model.Model getEntityById(String id, boolean includeSignatures) throws RecordNotFoundException, EncryptionException, AuditFailedException;
 
 	//public boolean deleteEntity(Model rdfModel) throws AuditFailedException, RecordNotFoundException;
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -108,26 +108,23 @@ public class RegistryServiceImpl implements RegistryService {
 	}
 
 
+	/**
+	 * Optionally gets signatures along with other information.
+	 *
+	 * @param label
+	 * @param includeSignatures
+	 * @return
+	 * @throws RecordNotFoundException
+	 * @throws EncryptionException
+	 * @throws AuditFailedException
+	 */
 	@Override
-	public org.eclipse.rdf4j.model.Model getEntityById(String label) throws RecordNotFoundException, EncryptionException, AuditFailedException {
-		Graph graph = registryDao.getEntityById(label);
+	public org.eclipse.rdf4j.model.Model getEntityById(String label, boolean includeSignatures) throws RecordNotFoundException, EncryptionException, AuditFailedException {
+		Graph graph = registryDao.getEntityById(label, includeSignatures);
 		org.eclipse.rdf4j.model.Model model = RDF2Graph.convertGraph2RDFModel(graph, label);
 		logger.debug("RegistryServiceImpl : rdf4j model :", model);
 		return model;
 	}
-
-	/*@Override
-	public boolean deleteEntity(Model rdfModel) throws AuditFailedException, RecordNotFoundException{
-		StmtIterator iterator = rdfModel.listStatements();
-		Graph graph = GraphDBFactory.getEmptyGraph();
-		while (iterator.hasNext()) {
-			Statement rdfStatement = iterator.nextStatement();
-			org.eclipse.rdf4j.model.Statement rdf4jStatement = JenaRDF4J.asrdf4jStatement(rdfStatement);
-			graph = RDF2Graph.convertRDFStatement2Graph(rdf4jStatement, graph);
-		}
-
-		return registryDao.deleteEntity(graph, "");
-	}*/
 
 	public HealthCheckResponse health() throws Exception {
 		HealthCheckResponse healthCheck;
@@ -226,7 +223,7 @@ public class RegistryServiceImpl implements RegistryService {
 	public org.eclipse.rdf4j.model.Model getAuditNode(String id) throws IOException, NoSuchElementException, RecordNotFoundException,
 			EncryptionException, AuditFailedException {
 		String label = id + "-AUDIT";
-		Graph graph = registryDao.getEntityById(label);
+		Graph graph = registryDao.getEntityById(label, false);
 		org.eclipse.rdf4j.model.Model model = RDF2Graph.convertGraph2RDFModel(graph, label);
 		logger.debug("RegistryServiceImpl : Audit Model : " + model);
 		return model;

--- a/java/registry/src/test/java/io/opensaber/registry/dao/impl/EncryptionDaoImplTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/dao/impl/EncryptionDaoImplTest.java
@@ -1,14 +1,25 @@
 package io.opensaber.registry.dao.impl;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.opensaber.registry.authorization.AuthorizationToken;
 import io.opensaber.registry.authorization.pojos.AuthInfo;
+import io.opensaber.registry.config.GenericConfiguration;
+import io.opensaber.registry.controller.RegistryTestBase;
+import io.opensaber.registry.dao.RegistryDao;
+import io.opensaber.registry.exception.EncryptionException;
+import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.model.AuditRecordReader;
 import io.opensaber.registry.schema.config.SchemaConfigurator;
+import io.opensaber.registry.service.impl.EncryptionServiceImpl;
 import io.opensaber.registry.sink.DatabaseProvider;
 import io.opensaber.registry.tests.utility.TestHelper;
-
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
@@ -32,29 +43,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
-import io.opensaber.registry.config.GenericConfiguration;
-import io.opensaber.registry.controller.RegistryTestBase;
-import io.opensaber.registry.dao.RegistryDao;
-import io.opensaber.registry.exception.EncryptionException;
-import io.opensaber.registry.middleware.util.Constants;
-import io.opensaber.registry.service.impl.EncryptionServiceImpl;
+import java.io.InputStreamReader;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import java.io.InputStreamReader;
-import java.util.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
 
 
 @RunWith(SpringRunner.class)
@@ -223,7 +218,7 @@ public class EncryptionDaoImplTest extends RegistryTestBase {
 
 		getVertexWithMultipleProperties(label, map);
 		String response = registryDao.addEntity(graph,label, null, null);
-		registryDao.getEntityById(response);
+		registryDao.getEntityById(response, false);
 		verify(encryptionMock, times(1)).encrypt(Mockito.anyMap());
 	}
 
@@ -248,7 +243,7 @@ public class EncryptionDaoImplTest extends RegistryTestBase {
 
 		getVertexWithMultipleProperties(label, map);
 		String response = registryDao.addEntity(graph, label, null, null);
-		registryDao.getEntityById(response);
+		registryDao.getEntityById(response, false);
 
 		verify(encryptionMock, times(1)).encrypt(Mockito.anyMap());
 	}
@@ -288,7 +283,7 @@ public class EncryptionDaoImplTest extends RegistryTestBase {
 		when(encryptionMock.encrypt("III")).thenReturn("mockEncryptedClassesTaughtIII");
 
 		String response =registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		registryDao.getEntityById(response);
+		registryDao.getEntityById(response, false);
 
 		verify(encryptionMock, times(1)).encrypt(Mockito.anyMap());
 		verify(encryptionMock, times(3)).encrypt(Mockito.anyString());
@@ -344,7 +339,7 @@ public class EncryptionDaoImplTest extends RegistryTestBase {
 
 		getVertexWithMultipleProperties(label,map);		
 		String response = registryDao.addEntity(graph, label, null, null);
-		registryDao.getEntityById(response);		
+		registryDao.getEntityById(response, false);
 
 		verify(encryptionMock, times(1)).encrypt(Mockito.anyMap());
 		verify(encryptionMock, times(1)).decrypt(Mockito.anyMap());
@@ -390,8 +385,8 @@ public class EncryptionDaoImplTest extends RegistryTestBase {
 		when(encryptionMock.decrypt(newMap)).thenReturn(map);
 
 
-		String response =registryDao.addEntity(graph, "_:"+rootLabel, null, null);					
-		registryDao.getEntityById(response);
+		String response =registryDao.addEntity(graph, "_:"+rootLabel, null, null);
+		registryDao.getEntityById(response, false);
 
 		verify(encryptionMock, times(1)).encrypt(Mockito.anyMap());	
 		verify(encryptionMock, times(1)).decrypt(Mockito.anyMap());		
@@ -418,7 +413,7 @@ public class EncryptionDaoImplTest extends RegistryTestBase {
 
 		try {
 			String response = registryDao.addEntity(graph, String.format("_:%s", label), null, null);
-			registryDao.getEntityById(response);
+			registryDao.getEntityById(response, false);
 		} catch (EncryptionException e) {
 			assertThat(e.toString(), allOf(containsString("EncryptionException")));
 		}

--- a/java/registry/src/test/java/io/opensaber/registry/dao/impl/RegistryDaoImplTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/dao/impl/RegistryDaoImplTest.java
@@ -1,17 +1,29 @@
 package io.opensaber.registry.dao.impl;
 
+import io.opensaber.converters.JenaRDF4J;
 import io.opensaber.registry.authorization.AuthorizationToken;
 import io.opensaber.registry.authorization.pojos.AuthInfo;
-import io.opensaber.registry.exception.AuditFailedException;
+import io.opensaber.registry.config.GenericConfiguration;
+import io.opensaber.registry.controller.RegistryTestBase;
+import io.opensaber.registry.exception.*;
 import io.opensaber.registry.exception.audit.LabelCannotBeNullException;
+import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.middleware.util.RDFUtil;
 import io.opensaber.registry.model.AuditRecordReader;
+import io.opensaber.registry.service.impl.EncryptionServiceImpl;
 import io.opensaber.registry.sink.DatabaseProvider;
 import io.opensaber.registry.tests.utility.TestHelper;
-
+import io.opensaber.utils.converters.RDF2Graph;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.rdf.model.Property;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.*;
+import org.apache.tinkerpop.gremlin.structure.io.IoCore;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
+import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.apache.tinkerpop.shaded.jackson.databind.ObjectMapper;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
@@ -30,31 +42,14 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.structure.io.IoCore;
-import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
-import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import io.opensaber.converters.JenaRDF4J;
-import io.opensaber.registry.config.GenericConfiguration;
-import io.opensaber.registry.controller.RegistryTestBase;
-import io.opensaber.registry.exception.DuplicateRecordException;
-import io.opensaber.registry.exception.EncryptionException;
-import io.opensaber.registry.exception.EntityCreationException;
-import io.opensaber.registry.exception.MultipleEntityException;
-import io.opensaber.registry.exception.RecordNotFoundException;
-import io.opensaber.registry.middleware.util.Constants;
-import io.opensaber.registry.middleware.util.RDFUtil;
-import io.opensaber.registry.service.impl.EncryptionServiceImpl;
-import io.opensaber.utils.converters.RDF2Graph;
+
+import java.io.IOException;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import java.io.IOException;
-import java.util.*;
 
 
 @RunWith(SpringRunner.class)
@@ -127,7 +122,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String label = generateRandomId();
 		getVertexForSubject(label, "http://example.com/voc/teacher/1.0.0/schoolName", "DAV Public School");
 		String response = registryDao.addEntity(graph, label,null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		assertEquals(1, IteratorUtils.count(entity.traversal().clone().V()));
 		Vertex v = entity.traversal().V().has(T.label, response).next();
 		assertEquals("DAV Public School", v.property("http://example.com/voc/teacher/1.0.0/schoolName").value());
@@ -194,7 +189,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		registryDao.addEntity(entity, response, null, null);
 	}
 	
@@ -203,7 +198,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		long vertexCount = IteratorUtils.count(entity.traversal().clone().V());
 		assertEquals(5, vertexCount);
         checkIfAuditRecordsAreRight(entity, null);
@@ -220,7 +215,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 
 			String entity1Label = registryDao.addEntity(graphEntity1, "_:" + rootLabelEntity1, null, null);
 
-			Graph entity1 = registryDao.getEntityById(entity1Label);
+			Graph entity1 = registryDao.getEntityById(entity1Label, false);
             checkIfAuditRecordsAreRight(entity1, null);
 
 			// Expected count of vertices in one entity
@@ -231,7 +226,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 			String rootLabelEntity2 = updateGraphFromRdf(rdfModel2, graphEntity2);
 			String entity2Label = registryDao.addEntity(graphEntity2, "_:" + rootLabelEntity2, null, null);
 
-			Graph entity2 = registryDao.getEntityById(entity2Label);
+			Graph entity2 = registryDao.getEntityById(entity2Label, false);
             checkIfAuditRecordsAreRight(entity2, null);
 
 			assertEquals(5, IteratorUtils.count(entity2.traversal().V()));
@@ -265,7 +260,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
         printModel(rdfModel);
         String newEntityResponse;
         newEntityResponse = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-        Graph entity = registryDao.getEntityById(newEntityResponse);
+		Graph entity = registryDao.getEntityById(newEntityResponse, false);
         logger.debug("-------- CHECKING AUDIT RECORDS-------");
         int count1 = checkIfAuditRecordsAreRight(entity, null);
         logger.debug("--------- AUDIT RECORDS -------"+count1);
@@ -286,7 +281,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String newRootLabel = updateGraphFromRdf(newRdfModel, newEntityGraph);
         printModel(newRdfModel);
 		newEntityResponse = registryDao.addEntity(newEntityGraph, String.format("_:%s", newRootLabel), null, null);
-		entity = registryDao.getEntityById(newEntityResponse);
+		entity = registryDao.getEntityById(newEntityResponse, false);
         int count2 = checkIfAuditRecordsAreRight(entity, null);
         logger.debug("------- AUDIT RECORDS ------"+count2);
 		String propertyValue = (String) entity.traversal().clone().V()
@@ -316,7 +311,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		TinkerGraph graph = TinkerGraph.open();
 		String rootLabel = updateGraphFromRdf(rdfModel, graph);
 		String label = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-        Graph entity0 = registryDao.getEntityById(label);
+		Graph entity0 = registryDao.getEntityById(label, false);
         checkIfAuditRecordsAreRight(entity0, null);
 		// Create a new TinkerGraph with the existing jsonld
 		Graph newEntityGraph = TinkerGraph.open();
@@ -336,7 +331,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String newRootLabel = updateGraphFromRdf(newRdfModel, newEntityGraph);
 
 		String newEntityResponse = registryDao.addEntity(newEntityGraph, String.format("_:%s", newRootLabel), null, null);
-		Graph entity = registryDao.getEntityById(newEntityResponse);
+		Graph entity = registryDao.getEntityById(newEntityResponse, false);
 		Map<String,Map<String,Integer>> updateCountMap = new HashMap<>();
         Map<String,Integer> updatePropCountMap = new HashMap<>();
         updatePropCountMap.put("http://example.com/voc/teacher/1.0.0/municipality",1);
@@ -358,7 +353,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		expectedEx.expect(RecordNotFoundException.class);
 		expectedEx.expectMessage(Constants.ENTITY_NOT_FOUND);
 		UUID label = getLabel();
-		registryDao.getEntityById(label.toString());
+		registryDao.getEntityById(label.toString(), false);
 	}
 
 	@Test
@@ -371,7 +366,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String label2 = UUID.randomUUID().toString();
 		getVertexForSubject(label1, "http://example.com/voc/teacher/1.0.0/schoolName", "DAV Public School");
 		registryDao.addEntity(graph, label1, null, null);
-		registryDao.getEntityById(label2);
+		registryDao.getEntityById(label2, false);
 	}
 
 	private void dump_graph(Graph g,String filename) throws IOException {
@@ -385,7 +380,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String label = getLabel().toString();
 		getVertexForSubject(label, "http://example.com/voc/teacher/1.0.0/schoolName", "DAV Public School");
 		String response = registryDao.addEntity(graph, label, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		assertNotNull(entity);
 //		TODO Write a better checker
 		assertEquals(countGraphVertices(graph), countGraphVertices(entity));
@@ -398,7 +393,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		assertNotNull(entity);
 		assertEquals(countGraphVertices(graph), countGraphVertices(entity));
 	}
@@ -410,7 +405,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdfWithFirstNodeAsBlankNode(rdfModel);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		assertNotNull(entity);
 		assertEquals(countGraphVertices(graph),countGraphVertices(entity));
 	}
@@ -423,7 +418,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		TinkerGraph graph = TinkerGraph.open();
 		String rootLabel = updateGraphFromRdf(rdfModel, graph);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 
 		GraphTraversal<Vertex, Vertex> blankNodes = entity.traversal().clone().V().filter(v -> v.get().label().startsWith("_:")).V();
 		assertEquals(0, IteratorUtils.count(blankNodes));
@@ -455,7 +450,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		TinkerGraph graph = TinkerGraph.open();
 		String rootLabel = updateGraphFromRdf(rdfModel, graph);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-        Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		checkIfAuditRecordsAreRight(entity,null);
 
 		Model updateRdfModel = createRdfFromFile("update_node.jsonld", response);
@@ -467,7 +462,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		updateGraphFromRdf(updateRdfModel, updateGraph);
 		registryDao.updateEntity(updateGraph, response, "update");
 
-		Graph updatedGraphResult = registryDao.getEntityById(response);
+		Graph updatedGraphResult = registryDao.getEntityById(response, false);
 
         /*Model updateRdfModelWithoutType = getModelwithOnlyUpdateFacts(rdfModel, updateRdfModel,Arrays.asList());
         checkIfAuditRecordsAreRight(updatedGraphResult,generateUpdateMapFromRDF(updateRdfModelWithoutType));*/
@@ -613,7 +608,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		TinkerGraph graph = TinkerGraph.open();
 		String rootLabel = updateGraphFromRdf(rdfModel, graph);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		Model updateRdfModel = createRdfFromFile("update_node.jsonld", response);
 		removeStatementFromModel(updateRdfModel, ResourceFactory.createProperty("http://example.com/voc/teacher/1.0.0/address"));
 		updateNodeLabel(updateRdfModel, "http://example.com/voc/teacher/1.0.0/School");
@@ -623,7 +618,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		updateGraphFromRdf(updateRdfModel, updateGraph);
 		registryDao.updateEntity(updateGraph, response, "update");
 
-		Graph updatedGraphResult = registryDao.getEntityById(response);
+		Graph updatedGraphResult = registryDao.getEntityById(response, false);
 
         /*Model updateRdfModelWithoutType = getModelwithOnlyUpdateFacts(rdfModel, updateRdfModel,Arrays.asList());
         checkIfAuditRecordsAreRight(updatedGraphResult,generateUpdateMapFromRDF(updateRdfModelWithoutType));*/
@@ -655,7 +650,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Graph graph = TinkerGraph.open();
 		String rootLabel = updateGraphFromRdf(rdfModel, graph);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		Model updateRdfModel = getNewValidRdf("add_node.jsonld");
 
 		// Call add entity
@@ -663,9 +658,9 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String label = getRootLabel(updateRdfModel);
 		generateGraphFromRDF(updateGraph, updateRdfModel);
 		String newResponse = registryDao.addEntity(updateGraph,label, response, "http://example.com/voc/teacher/1.0.0/address");
-		Graph newUpdatedGraphResult = registryDao.getEntityById(newResponse);
+		Graph newUpdatedGraphResult = registryDao.getEntityById(newResponse, false);
 		assertEquals(2, IteratorUtils.count(newUpdatedGraphResult.traversal().clone().V()));
-		Graph updatedGraphResult = registryDao.getEntityById(response);
+		Graph updatedGraphResult = registryDao.getEntityById(response, false);
         /*Model updateRdfModelWithoutType = getModelwithOnlyUpdateFacts(rdfModel, updateRdfModel,Arrays.asList("http://example.com/voc/teacher/1.0.0/address"));
         checkIfAuditRecordsAreRight(updatedGraphResult,generateUpdateMapFromRDF(updateRdfModelWithoutType));*/
 		Model addedModel = JenaRDF4J.asJenaModel(RDF2Graph.convertGraph2RDFModel(entity, response));
@@ -699,7 +694,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		TinkerGraph graph = TinkerGraph.open();
 		String rootLabel = updateGraphFromRdf(rdfModel, graph);
 		String response = registryDao.addEntity(graph, "_:"+rootLabel, null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		Model addedModel = JenaRDF4J.asJenaModel(RDF2Graph.convertGraph2RDFModel(entity, response));
 		Model updateRdfModel = createRdfFromFile("update_node.jsonld", response);
 		StmtIterator stmt = addedModel.listStatements(ResourceFactory.createResource(response), ResourceFactory.createProperty("http://example.com/voc/teacher/1.0.0/address"),(RDFNode)null);
@@ -722,7 +717,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		generateGraphFromRDF(updateGraph, updateRdfModel);
 		registryDao.updateEntity(updateGraph, response, "update");
 
-		Graph updatedGraphResult = registryDao.getEntityById(response);
+		Graph updatedGraphResult = registryDao.getEntityById(response, false);
 
         /*Model updateRdfModelWithoutType = getModelwithOnlyUpdateFacts(rdfModel, updateRdfModel,Arrays.asList("http://example.com/voc/teacher/1.0.0/address"));
         checkIfAuditRecordsAreRight(updatedGraphResult,generateUpdateMapFromRDF(updateRdfModelWithoutType));*/
@@ -791,7 +786,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
         Model inputModel = getNewValidRdf(RICH_LITERAL_TTL, "ex:");
         String rootLabel = updateGraphFromRdf(inputModel, graph);
         registryDao.addEntity(graph, rootLabel, null, null);
-        Graph entity = registryDao.getEntityById(rootLabel);
+		Graph entity = registryDao.getEntityById(rootLabel, false);
         org.eclipse.rdf4j.model.Model model = RDF2Graph.convertGraph2RDFModel(entity, rootLabel);
         Model outputModel = JenaRDF4J.asJenaModel(model);
         assertTrue(inputModel.difference(outputModel).isEmpty());
@@ -912,7 +907,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		GraphTraversal<Vertex, Vertex> updatedgraphTraversal = entity.traversal().clone().V();
 		while (updatedgraphTraversal.hasNext()) {
 			Vertex v = updatedgraphTraversal.next();
@@ -970,7 +965,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		checkIfAuditRecordsAreRight(entity,null);
 
 		Model updateRdfModel = createRdfFromFile("update_node.jsonld", response);
@@ -981,7 +976,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		updateGraph = generateGraphFromRDF(updateGraph, updateRdfModel);
 		registryDao.updateEntity(updateGraph, response, "update");
 
-		Graph updatedGraphResult = registryDao.getEntityById(response);
+		Graph updatedGraphResult = registryDao.getEntityById(response, false);
 
         /*Model updateRdfModelWithoutType = getModelwithOnlyUpdateFacts(rdfModel, updateRdfModel,Arrays.asList());
         checkIfAuditRecordsAreRight(updatedGraphResult,generateUpdateMapFromRDF(updateRdfModelWithoutType));*/
@@ -1002,7 +997,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		Model rdfModel = getNewValidRdf();
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		
 		checkIfAuditRecordsAreRight(entity,null);
 
@@ -1017,7 +1012,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		updateGraph = generateGraphFromRDF(updateGraph, updateRdfModel);
 		registryDao.updateEntity(updateGraph, response, "update");
 
-		Graph updatedGraphResult = registryDao.getEntityById(response);
+		Graph updatedGraphResult = registryDao.getEntityById(response, false);
 		Model addedModel = JenaRDF4J.asJenaModel(RDF2Graph.convertGraph2RDFModel(entity, response));
         Model updateRdfModelWithoutType = getModelwithOnlyUpdateFacts(addedModel, updateRdfModel,Arrays.asList());
         Model deletedFacts = getModelwithDeletedFacts(addedModel, updateRdfModel, updateRdfModelWithoutType);
@@ -1066,7 +1061,7 @@ public class RegistryDaoImplTest extends RegistryTestBase {
 		String rootLabel = updateGraphFromRdf(rdfModel);
 		String response = registryDao.addEntity(graph, String.format("_:%s", rootLabel), null, null);
 		registryDao.deleteEntityById(response);
-		registryDao.getEntityById(response);
+		registryDao.getEntityById(response, false);
 		//assertTrue(registryDao.deleteEntityById(response));
 	}
 

--- a/java/registry/src/test/java/io/opensaber/registry/dao/impl/SearchDaoImplTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/dao/impl/SearchDaoImplTest.java
@@ -1,12 +1,20 @@
 package io.opensaber.registry.dao.impl;
 
-import static org.junit.Assert.*;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
+import io.opensaber.converters.JenaRDF4J;
+import io.opensaber.pojos.Filter;
+import io.opensaber.pojos.SearchQuery;
+import io.opensaber.registry.app.OpenSaberApplication;
+import io.opensaber.registry.authorization.AuthorizationToken;
+import io.opensaber.registry.authorization.pojos.AuthInfo;
+import io.opensaber.registry.config.GenericConfiguration;
+import io.opensaber.registry.controller.RegistryTestBase;
+import io.opensaber.registry.dao.RegistryDao;
+import io.opensaber.registry.dao.SearchDao;
+import io.opensaber.registry.exception.*;
+import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.sink.DatabaseProvider;
+import io.opensaber.registry.tests.utility.TestHelper;
+import io.opensaber.utils.converters.RDF2Graph;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.RDF;
@@ -25,26 +33,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import io.opensaber.converters.JenaRDF4J;
-import io.opensaber.pojos.Filter;
-import io.opensaber.pojos.SearchQuery;
-import io.opensaber.registry.app.OpenSaberApplication;
-import io.opensaber.registry.authorization.AuthorizationToken;
-import io.opensaber.registry.authorization.pojos.AuthInfo;
-import io.opensaber.registry.config.GenericConfiguration;
-import io.opensaber.registry.controller.RegistryTestBase;
-import io.opensaber.registry.middleware.util.Constants;
-import io.opensaber.registry.sink.DatabaseProvider;
-import io.opensaber.registry.tests.utility.TestHelper;
-import io.opensaber.utils.converters.RDF2Graph;
-import io.opensaber.registry.dao.RegistryDao;
-import io.opensaber.registry.dao.SearchDao;
-import io.opensaber.registry.exception.AuditFailedException;
-import io.opensaber.registry.exception.DuplicateRecordException;
-import io.opensaber.registry.exception.EncryptionException;
-import io.opensaber.registry.exception.EntityCreationException;
-import io.opensaber.registry.exception.MultipleEntityException;
-import io.opensaber.registry.exception.RecordNotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {OpenSaberApplication.class,RegistryDao.class, SearchDao.class,
@@ -153,7 +147,7 @@ public class SearchDaoImplTest extends RegistryTestBase {
 		assertTrue(!responseGraph.isEmpty());
 		assertTrue(responseGraph.size() == 1);
 		assertTrue(responseGraph.containsKey(response));
-		Graph entity = registryDao.getEntityById(response);
+		Graph entity = registryDao.getEntityById(response, false);
 		Model addedModel = JenaRDF4J.asJenaModel(RDF2Graph.convertGraph2RDFModel(entity, response));
 		removeStatementFromModel(addedModel, ResourceFactory.createProperty("http://example.com/voc/teacher/1.0.0/schoolName"));
 		addedModel.add(ResourceFactory.createResource(response), 

--- a/java/registry/src/test/java/io/opensaber/registry/service/impl/RegistryServiceImplTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/service/impl/RegistryServiceImplTest.java
@@ -199,7 +199,7 @@ public class RegistryServiceImplTest extends RegistryTestBase {
 			model.add(roots.get(0), ResourceFactory.createProperty(registryContextBase+"classesTaught"), (String)obj);
 		}
 		String response = registryService.addEntity(model,null,null);
-		org.eclipse.rdf4j.model.Model responseModel = registryService.getEntityById(response);
+        org.eclipse.rdf4j.model.Model responseModel = registryService.getEntityById(response, false);
 		Model jenaModel = JenaRDF4J.asJenaModel(responseModel);
 		assertTrue(jenaModel.isIsomorphicWith(model));
 		closeDB();


### PR DESCRIPTION
Introduced an optional boolean query parameter by name "includeSignatures", that controls whether or not signatures must be part of the read response.
This is applicable only to 'read' api and 'search' api would not return the signatures at all.

While working on this I realised most of the test cases use getEntityById as a way to read back and assert. I think there is some opportunity here to relook at the usefulness of all these test cases and ensure they are 'really' necessary and can be maintained.