### PR TITLE
OS 68 - fix null exception while signature validation

### DIFF
--- a/java/middleware/registry-middleware/signature-presence-validation/src/main/java/io/opensaber/registry/middleware/impl/SignaturePresenceValidator.java
+++ b/java/middleware/registry-middleware/signature-presence-validation/src/main/java/io/opensaber/registry/middleware/impl/SignaturePresenceValidator.java
@@ -33,6 +33,7 @@ public class SignaturePresenceValidator implements Middleware{
 	private String registrySystemBase;
 	private Model schemaConfig;
 	private List<String> signatureTypes = new ArrayList<String>();
+	private List<String> signatureAttributes;
 
     // TODO: Instead of passing the ShapeType everytime, there could be a good reason
     // to read all the shapes at once and then start validating against what was read.
@@ -49,6 +50,7 @@ public class SignaturePresenceValidator implements Middleware{
 				signatureTypes.add(type);
 			}
 		});
+		signatureAttributes = getSignatureAttributes();
 	}
 
 	public Map<String, Object> execute(Map<String, Object> mapData) throws IOException, MiddlewareHaltException {
@@ -117,7 +119,6 @@ public class SignaturePresenceValidator implements Middleware{
 		Property property = ResourceFactory.createProperty(registrySystemBase + Constants.SIGNED_PROPERTY);
         StmtIterator rdfIter = rdfModel.listStatements();
 		Property prop = ResourceFactory.createProperty(registryContext+Constants.SIGNATURE_FOR);
-		List<String> signatureAttributes = getSignatureAttributes();
 		TypeMapper tm = TypeMapper.getInstance();
 		//This is the datatype for the signatureFor attribute
 		RDFDatatype rdt = tm.getSafeTypeByName(XMLConstants.W3C_XML_SCHEMA_NS_URI+"#anyURI");

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -245,12 +245,12 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	    }
 
 	    registry.addInterceptor(rdfConversionInterceptor())
-				.addPathPatterns("/add", "/update","/search").order(orderIdx);
+				.addPathPatterns("/add", "/update", "/search").order(orderIdx++);
 		registry.addInterceptor(rdfValidationInterceptor())
-				.addPathPatterns("/add", "/update").order(orderIdx);
+				.addPathPatterns("/add", "/update").order(orderIdx++);
 		if (signatureEnabled) {
 			registry.addInterceptor(signaturePresenceValidationInterceptor())
-					.addPathPatterns("/add", "/update").order(orderIdx);
+					.addPathPatterns("/add", "/update").order(orderIdx++);
 		}
 	}
 

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -59,6 +59,9 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	@Value("${authentication.enabled}")
 	private boolean authenticationEnabled;
 
+	@Value("${signature.enabled}")
+	private boolean signatureEnabled;
+
 	@Value("${perf.monitoring.enabled}")
 	private boolean performanceMonitoringEnabled;
 	
@@ -235,16 +238,20 @@ public class GenericConfiguration implements WebMvcConfigurer {
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
-	    if(authenticationEnabled) {
+		int orderIdx = 1;
+		if(authenticationEnabled) {
             registry.addInterceptor(authorizationInterceptor())
-                    .addPathPatterns("/**").excludePathPatterns("/health", "/error").order(1);
+                    .addPathPatterns("/**").excludePathPatterns("/health", "/error").order(orderIdx++);
 	    }
-		registry.addInterceptor(rdfConversionInterceptor())
-				.addPathPatterns("/add", "/update","/search").order(2);
+
+	    registry.addInterceptor(rdfConversionInterceptor())
+				.addPathPatterns("/add", "/update","/search").order(orderIdx);
 		registry.addInterceptor(rdfValidationInterceptor())
-				.addPathPatterns("/add", "/update").order(3);
-		registry.addInterceptor(signaturePresenceValidationInterceptor())
-		.addPathPatterns("/add", "/update").order(4);
+				.addPathPatterns("/add", "/update").order(orderIdx);
+		if (signatureEnabled) {
+			registry.addInterceptor(signaturePresenceValidationInterceptor())
+					.addPathPatterns("/add", "/update").order(orderIdx);
+		}
 	}
 
 	@Override

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -67,10 +67,10 @@ frame:
 
 encryption:
   enabled: ${encryption_enabled:true}
-  base: ${encryption_base:https://dev.open-sunbird.org/encryption/}
-  uri: ${encryption_uri:https://dev.open-sunbird.org/encryption/encrypt}
+  base: ${encryption_base:http://localhost:8013}
+  uri: ${encryption_uri:http://localhost:8013/encrypt}
   batch:
-    uri: ${encryption_batch_uri:https://dev.open-sunbird.org/encryption/encrypt/obj}
+    uri: ${encryption_batch_uri:http://localhost:8013/encrypt/obj}
   service:
     connection:
       timeout: ${encryption_service_connection_timeout:5000}
@@ -80,9 +80,9 @@ encryption:
       timeout: ${encryption_service_read_timeout:5000}
 
 decryption:
-  uri: ${decryption_uri:https://dev.open-sunbird.org/encryption/decrypt}
+  uri: ${decryption_uri:http://localhost:8013/decrypt}
   batch:
-    uri: ${decryption_batch_uri:https://dev.open-sunbird.org/encryption/decrypt/obj}
+    uri: ${decryption_batch_uri:http://localhost:8013/decrypt/obj}
 
 signature:
   enabled: ${signature_enabled:true}

--- a/java/registry/src/main/resources/validations_update.shex.sample
+++ b/java/registry/src/main/resources/validations_update.shex.sample
@@ -72,7 +72,7 @@ teacher:NonTeachingAssignmentsForAcademicCalendarShape CLOSED {
 }
 
 teacher:SignatureShape CLOSED {
-	a [sc:RsaSignature2018] ;
+	a [sc:LinkedDataSignature2015 sc:GraphSignature2012 sc:Signature sc:RsaSignature2018] ;
 	teacher:signatureFor @teacher:isAnyURI ;
 	teacher:creator @teacher:isACreator ;
 	teacher:created @teacher:isACreated ;


### PR DESCRIPTION
1. The list of attributes that needs to be checked for validation is pre-determined and is available at the time of application startup. This can well enough be part of the bean so that it is singleton and re-used without re-eval.

Post this fix, I tried the same command that was used to detect this as
`rajeshr$ /usr/local/bin/apib -f teacher_rtest2.json -c 5 -d 40 -H 'x-authenticated-user-token:<TOKEN>' http://localhost:8080/add
`
The perf is still low, but at least there is no new problem found.
2. While updating, tried giving all types of signature - this was disallowed before fix.
3. The signature interceptor is now limited to be injected only upon signature enablement.