### PR TITLE
Os 98 Read API changed to POST method

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -317,7 +317,7 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	    }
 
 	    registry.addInterceptor(rdfConversionInterceptor())
-				.addPathPatterns("/add", "/update", "/search").order(orderIdx++);
+				.addPathPatterns("/add", "/update", "/search", "/read").order(orderIdx++);
 	}
 
 	@Override


### PR DESCRIPTION
Changes Done
1. Read API changing from GET method type to POST method type.
2. Read API only supports JSON content type: since the request attibutes are not any LD related data.

Tested by postman
1. Read API testing is covered. 
