### PR TITLE
Issue #OS-125 Bump up version number

### DIFF
--- a/java/converters/jenardf4j/pom.xml
+++ b/java/converters/jenardf4j/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>converters</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>jenardf4j</artifactId>

--- a/java/converters/pom.xml
+++ b/java/converters/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>opensaber</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>converters</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Conversion utilities</name>
     <packaging>pom</packaging>
     <modules>

--- a/java/converters/rdf2Graph/pom.xml
+++ b/java/converters/rdf2Graph/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>converters</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>rdf2graph</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
     <name>rdf2graph</name>
 
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/java/middleware-commons/pom.xml
+++ b/java/middleware-commons/pom.xml
@@ -5,16 +5,15 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>opensaber</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
+        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>middleware-commons</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>middleware commons</name>
     <description>Common utilities and interfaces</description>
-    <properties>
-        <tinkerpop.version>3.3.1</tinkerpop.version>
-    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.github.jsonld-java</groupId>
@@ -29,7 +28,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>jenardf4j</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
@@ -45,7 +44,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>pojos</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/middleware/pom.xml
+++ b/java/middleware/pom.xml
@@ -5,19 +5,13 @@
     <parent>
         <artifactId>opensaber</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>middleware-bom</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
-    <properties>
-        <jsonldConversionVersion>1.0.0</jsonldConversionVersion>
-        <rdfConversionVersion>1.0.0</rdfConversionVersion>
-        <authorizationVersion>1.0.0</authorizationVersion>
-        <validationVersion>1.0.0</validationVersion>
-        <signaturePresenceValidationVersion>1.0.0</signaturePresenceValidationVersion>
-    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/java/middleware/registry-middleware/authorization/pom.xml
+++ b/java/middleware/registry-middleware/authorization/pom.xml
@@ -3,14 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
     <!-- <groupId>io.opensaber</groupId> -->
     <artifactId>authorization</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Authorization</name>
     <description>Authorization of requests</description>
 
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>registry-middleware</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/java/middleware/registry-middleware/jsonld-conversion/pom.xml
+++ b/java/middleware/registry-middleware/jsonld-conversion/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>registry-middleware</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>io.opensaber.middleware</groupId>
     <artifactId>jsonld-conversion</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>JSON-LD Conversion</name>
     <description>Conversion from rdf to json-ld</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>jenardf4j</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>

--- a/java/middleware/registry-middleware/pom.xml
+++ b/java/middleware/registry-middleware/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>registry-middleware</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <artifactId>middleware-bom</artifactId>
     </parent>
 

--- a/java/middleware/registry-middleware/rdf-conversion/pom.xml
+++ b/java/middleware/registry-middleware/rdf-conversion/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>registry-middleware</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>
@@ -13,7 +13,7 @@
 
     <groupId>io.opensaber.middleware</groupId>
     <artifactId>rdf-conversion</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>RDF Conversion</name>
     <description>Middleware to convert json-ld to rdf</description>
 
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/middleware/registry-middleware/validation/pom.xml
+++ b/java/middleware/registry-middleware/validation/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>registry-middleware</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>io.opensaber.middleware</groupId>
     <artifactId>validation</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Validation</name>
     <description>Middleware to validate inputs</description>
 
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/pojos/pom.xml
+++ b/java/pojos/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>opensaber</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>pojos</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>pojos</name>
     <url>http://maven.apache.org</url>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.opensaber</groupId>
     <artifactId>opensaber</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Open Software Archetype for Building Electronic Registries</name>
     <packaging>pom</packaging>
 
@@ -18,6 +18,15 @@
         <junit.version>4.12</junit.version>
         <neo4j.version>3.2.3</neo4j.version>
         <jacoco.version>0.8.1</jacoco.version>
+
+        <revision>1.1.0</revision>
+
+        <jsonldConversionVersion>${revision}</jsonldConversionVersion>
+        <rdfConversionVersion>${revision}</rdfConversionVersion>
+        <authorizationVersion>${revision}</authorizationVersion>
+        <validationVersion>${revision}</validationVersion>
+        <signaturePresenceValidationVersion>${revision}</signaturePresenceValidationVersion>
+
     </properties>
 
     <modules>

--- a/java/registry-interceptor/pom.xml
+++ b/java/registry-interceptor/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>opensaber</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
     <groupId>io.opensaber</groupId>
     <artifactId>registry-interceptor</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>registry-interceptors</name>
@@ -21,7 +21,7 @@
              <dependency>
                 <groupId>io.opensaber</groupId>
                 <artifactId>middleware-bom</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency> 
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>pojos</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         
         <dependency>

--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>io.opensaber</groupId>
                 <artifactId>validators</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -49,12 +49,12 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>jenardf4j</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>rdf2graph</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.jena</groupId>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>registry-interceptor</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>
@@ -285,7 +285,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>schema-configuration</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <!--<dependency>-->
         <!--<groupId>io.opensaber</groupId>-->
@@ -300,7 +300,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>transaction-event-handler</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -324,13 +324,13 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>shaclex</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>jsonschemavalidator</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/java/schema-configuration/pom.xml
+++ b/java/schema-configuration/pom.xml
@@ -25,11 +25,11 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>opensaber</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>schema-configuration</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Schema configuration</name>
     <description>Configurations for fields</description>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/transaction-event-handler/pom.xml
+++ b/java/transaction-event-handler/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>opensaber</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>transaction-event-handler</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Transaction Event Handler</name>
     <description>Handling database transaction events</description>
 
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/java/validators/json/jsonschema/pom.xml
+++ b/java/validators/json/jsonschema/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonvalidator</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
     </repositories>
 
     <artifactId>jsonschemavalidator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>JSON schema based validation</name>
 
     <dependencies>

--- a/java/validators/json/pom.xml
+++ b/java/validators/json/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>validators</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <groupId>io.opensaber</groupId>
     </parent>
 
     <artifactId>jsonvalidator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>Json based Validation</name>
     <packaging>pom</packaging>
     <modules>

--- a/java/validators/pom.xml
+++ b/java/validators/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.opensaber</groupId>
     <artifactId>validators</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
     <name>validators</name>
     <url>http://maven.apache.org</url>
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.opensaber</groupId>
         <artifactId>opensaber</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <modules>
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.opensaber.middleware</groupId>
             <artifactId>validation</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/validators/rdf/pom.xml
+++ b/java/validators/rdf/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>validators</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <groupId>io.opensaber</groupId>
     </parent>
 
     <artifactId>rdfvalidator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>ShEx based RDF Validation utilities</name>
     <packaging>pom</packaging>
     <modules>

--- a/java/validators/rdf/shaclex/pom.xml
+++ b/java/validators/rdf/shaclex/pom.xml
@@ -24,11 +24,11 @@
     <parent>
         <artifactId>rdfvalidator</artifactId>
         <groupId>io.opensaber</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>shaclex</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <name>shaclex</name>
 
     <dependencies>


### PR DESCRIPTION
Brought in version numbers to the registry pom file as properties. Looks like the idea was to have multi-version support, but am not sure if this fits well to current codebase structure - most of them are compile time dependencies.

Procedure:
1. `mvn versions:set -DnewVersion=1.1.0`
2. Add/Change `<revision>1.1.0</revision>` in opensaber\java\pom.xml
3. `mvn clean install`

I dislike the fact that we had to modify this many number of files and will create a todo for us to simplify this in the next release.