### PR TITLE
OS-137 Make Graph transient as a http request

### DIFF
--- a/java/middleware-commons/src/main/java/io/opensaber/registry/transform/Json2LdTransformer.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/transform/Json2LdTransformer.java
@@ -43,11 +43,11 @@ public class Json2LdTransformer implements ITransformer<Object> {
 				throw new TransformationException(Constants.INVALID_FRAME, ErrorCode.JSON_TO_JSONLD_TRANFORMATION_ERROR);
 			setPrefix(domain);
 			JSONUtil.addPrefix(resultNode, prefix, nodeTypes);
-			logger.info("Appending prefix to requestNode " + resultNode);
+			logger.debug("Appended prefix to requestNode.");
 
 			resultNode = (ObjectNode) resultNode.path(rootType);
 			resultNode.setAll(fieldObjects);
-			logger.info("Object requestnode " + resultNode);
+
 			String jsonldResult = mapper.writeValueAsString(resultNode);
 			return new Data<>(jsonldResult.replace("<@type>", rootType));
 		} catch (Exception ex) {
@@ -78,7 +78,6 @@ public class Json2LdTransformer implements ITransformer<Object> {
 				nodeTypes.add(entry.getKey());
 			}
 		});
-		logger.info("nodeType size " + nodeTypes.size());
 	}
 
 	private void setPrefix(String type) {

--- a/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
@@ -68,7 +68,6 @@ public class RegistryDaoImpl implements RegistryDao {
 	@Autowired
 	private UrlValidator urlValidator;
 
-
 	public static String generateRandomUUID() {
 		return UUID.randomUUID().toString();
 	}

--- a/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/impl/RegistryDaoImpl.java
@@ -68,6 +68,7 @@ public class RegistryDaoImpl implements RegistryDao {
 	@Autowired
 	private UrlValidator urlValidator;
 
+
 	public static String generateRandomUUID() {
 		return UUID.randomUUID().toString();
 	}

--- a/java/registry/src/main/java/io/opensaber/registry/model/DBConnectionInfo.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/DBConnectionInfo.java
@@ -6,7 +6,7 @@ public class DBConnectionInfo {
 	private String uri;
 	private String username;
 	private String password;
-	private boolean enableProfiler = false;
+	private boolean profilerEnabled = false;
 	
 	public String getShardId() {
 		return shardId;
@@ -35,11 +35,11 @@ public class DBConnectionInfo {
 	}
 
 
-	public boolean isEnableProfiler() {
-		return enableProfiler;
+	public boolean isProfilerEnabled() {
+		return profilerEnabled;
 	}
 
-	public void setEnableProfiler(boolean enableProfiler) {
-		this.enableProfiler = enableProfiler;
+	public void setProfilerEnabled(boolean profilerEnabled) {
+		this.profilerEnabled = profilerEnabled;
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/model/DBConnectionInfo.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/DBConnectionInfo.java
@@ -6,6 +6,7 @@ public class DBConnectionInfo {
 	private String uri;
 	private String username;
 	private String password;
+	private boolean enableProfiler = false;
 	
 	public String getShardId() {
 		return shardId;
@@ -31,5 +32,14 @@ public class DBConnectionInfo {
 	}
 	public void setPassword(String password) {
 		this.password = password;
+	}
+
+
+	public boolean isEnableProfiler() {
+		return enableProfiler;
+	}
+
+	public void setEnableProfiler(boolean enableProfiler) {
+		this.enableProfiler = enableProfiler;
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
@@ -40,21 +40,29 @@ public abstract class DatabaseProvider {
 	 * This method is used to initialize some global graph level configuration
 	 */
 	public void initializeGlobalGraphConfiguration() {
-		if (IteratorUtils.count(getGraphStore().traversal().V().has(T.label, Constants.GRAPH_GLOBAL_CONFIG)) == 0) {
+		Graph graph = getGraphStore();
+		if (IteratorUtils.count(graph.traversal().V().has(T.label, Constants.GRAPH_GLOBAL_CONFIG)) == 0) {
 			logger.info("Adding GRAPH_GLOBAL_CONFIG node...");
-			if (getGraphStore().features().graph().supportsTransactions()) {
+			if (graph.features().graph().supportsTransactions()) {
 				org.apache.tinkerpop.gremlin.structure.Transaction tx;
-				tx = getGraphStore().tx();
+				tx = graph.tx();
 				tx.onReadWrite(org.apache.tinkerpop.gremlin.structure.Transaction.READ_WRITE_BEHAVIOR.AUTO);
-				Vertex globalConfig = getGraphStore().traversal().clone().addV(Constants.GRAPH_GLOBAL_CONFIG).next();
+				Vertex globalConfig = graph.traversal().clone().addV(Constants.GRAPH_GLOBAL_CONFIG).next();
 				globalConfig.property(Constants.PERSISTENT_GRAPH, true);
 				tx.commit();
-				logger.debug("Graph initialised using transaction !");
+				logger.info("Graph initialised using transaction !");
 			} else {
-				Vertex globalConfig = getGraphStore().traversal().clone().addV(Constants.GRAPH_GLOBAL_CONFIG).next();
+				Vertex globalConfig = graph.traversal().clone().addV(Constants.GRAPH_GLOBAL_CONFIG).next();
 				globalConfig.property(Constants.PERSISTENT_GRAPH, true);
-				logger.debug("Graph initialised without transaction !");
+				logger.info("Graph initialised without transaction !");
 			}
+		}
+		try {
+			graph.close();
+		} catch (Exception e) {
+			// This function is called at boot time and any exception thrown here indicates very serious
+			// problem.
+			logger.error("Can't close graph " + e.getMessage());
 		}
 	}
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -29,7 +29,7 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 
 	public Neo4jGraphProvider(DBConnectionInfo connection) {
 		connectionInfo = connection;
-		profilerEnabled = connection.isEnableProfiler();
+		profilerEnabled = connection.isProfilerEnabled();
 		// TODO: Check with auth
 		driver = GraphDatabase.driver(connection.getUri(),
 				AuthTokens.none());

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -3,8 +3,10 @@ package io.opensaber.registry.sink;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.neo4j.structure.Neo4jGraph;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
@@ -20,34 +22,54 @@ import io.opensaber.registry.model.DBConnectionInfo;
 public class Neo4jGraphProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(Neo4jGraphProvider.class);
-
 	private Driver driver;
-	private Graph graph;
+	private boolean profilerEnabled;
+	private DBConnectionInfo connectionInfo;
+	private Neo4JElementIdProvider<?> idProvider = new Neo4JNativeElementIdProvider();
 
 	public Neo4jGraphProvider(DBConnectionInfo connection) {
+		connectionInfo = connection;
+		profilerEnabled = connection.isEnableProfiler();
+		// TODO: Check with auth
+		driver = GraphDatabase.driver(connection.getUri(),
+				AuthTokens.none());
+		logger.info("Initialized db at ", connectionInfo.getUri());
+	}
 
-		try {
-			AuthToken authToken = AuthTokens.basic(connection.getUsername(), connection.getPassword());
-			if (authToken != null) {
-				driver = GraphDatabase.driver(connection.getUri(), authToken);
-			} else {
-				driver = GraphDatabase.driver(connection.getUri(), AuthTokens.none());
+
+	private static int nCalls = 0;
+
+	private Graph getGraph() {
+		Neo4jGraphProvider.nCalls++;
+		logger.info("number of calls " + nCalls);
+
+		Graph graph;
+		Boolean isDatabaseEmbedded = false;
+		if (isDatabaseEmbedded) {
+			// We don't want to run in embedded mode; maybe allowed only for expert users.
+			String graphDbLocation = "/data"; // INIT this to neo4j data directory
+			logger.info(String.format("Initializing graph db at %s ...", graphDbLocation));
+			Configuration config = new BaseConfiguration();
+			config.setProperty(Neo4jGraph.CONFIG_DIRECTORY, graphDbLocation);
+			config.setProperty("gremlin.neo4j.conf.cache_type", "none");
+			graph = Neo4jGraph.open(config);
+		} else {
+			try {
+				Neo4JGraph neo4JGraph = new Neo4JGraph(driver, idProvider, idProvider);
+				neo4JGraph.setProfilerEnabled(profilerEnabled);
+				graph = neo4JGraph;
+
+			} catch (Exception ex) {
+				logger.error("Exception when initializing Neo4J DB connection...", ex);
+				throw ex;
 			}
-
-			Neo4JElementIdProvider<?> idProvider = new Neo4JNativeElementIdProvider();
-			Neo4JGraph neo4JGraph = new Neo4JGraph(driver, idProvider, idProvider);
-			// neo4JGraph.setProfilerEnabled(profilerEnabled);
-			graph = neo4JGraph;
-			logger.info("Initializing remote graph db for " + connection.getShardId());
-		} catch (Exception ex) {
-			logger.error("Exception when initializing Neo4J DB connection...", ex);
-			throw ex;
 		}
+		return graph;
 	}
 
 	@Override
 	public Graph getGraphStore() {
-		return graph;
+		return getGraph();
 	}
 
 	@PostConstruct
@@ -62,10 +84,9 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 		logger.info("**************************************************************************");
 		logger.info("Gracefully shutting down Neo4J GraphDB instance ...");
 		logger.info("**************************************************************************");
-		graph.close();
+
 		if (driver != null) {
 			driver.close();
 		}
 	}
-
 }

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -37,16 +37,16 @@ database:
   #Note: Please avoid repeating the shardId.
   provider: ${database_provider:NEO4J}
   connectionInfo:
-    - 
+    -
       shardId: shard1
-      uri: ${shard1_url:bolt://localhost:7687}
-      username: ${shard1_username: neo4j}
-      password: ${shard1_password: }
-    - 
+      uri: ${connectionInfo_uri:bolt://localhost:7687}
+      username: ${connectionInfo_username:neo4j}
+      password: ${connectionInfo_password:test123}
+    -
       shardId: shard2
-      uri: ${shard2_url: bolt://localhost:7688}
-      username: ${shard2_username: neo4j}
-      password: ${shard2_password: }
+      uri: ${connectionInfo_uri:bolt://localhost:7688}
+      username: ${connectionInfo_username:neo4j}
+      password: ${connectionInfo_password:test123}
 
 ##################################################################################
 # Uncomment the following section to use Cassandra as backend store              #
@@ -152,8 +152,7 @@ config:
     file: schema-configuration-school-test.jsonld
 
 database:
-  #provider available are NEO4J, SQLG, TINKERGRAPH, CASSANDRA, ORIENTDB.
-  #Note: Please avoid repeating the shardId.
+  # Any other provider breaks the unit tests, needs a work-item
   provider: TINKERGRAPH
 
 # File for framing the entity while reading

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -39,14 +39,14 @@ database:
   connectionInfo:
     - 
       shardId: shard1
-      uri: bolt://localhost:7688
-      username: neo4j
-      password: neo4j@tt
+      uri: ${shard1_url:bolt://localhost:7687}
+      username: ${shard1_username: neo4j}
+      password: ${shard1_password: }
     - 
       shardId: shard2
-      uri: bolt://localhost:7689
-      username: neo4j
-      password: neo4j@tt
+      uri: ${shard2_url: bolt://localhost:7688}
+      username: ${shard2_username: neo4j}
+      password: ${shard2_password: }
 
 ##################################################################################
 # Uncomment the following section to use Cassandra as backend store              #
@@ -152,6 +152,8 @@ config:
     file: schema-configuration-school-test.jsonld
 
 database:
+  #provider available are NEO4J, SQLG, TINKERGRAPH, CASSANDRA, ORIENTDB.
+  #Note: Please avoid repeating the shardId.
   provider: TINKERGRAPH
 
 # File for framing the entity while reading


### PR DESCRIPTION
We learnt that we were using Graph throughout the application life scope contrary to the recommendation by the library developers - See https://github.com/SteelBridgeLabs/neo4j-gremlin-bolt/issues/78 for more details.
To abide by the recommendation, the changes here are proposed.

The driver is initialised once and the graph objects working with it are done per request. 

**Other changes**
- Changed log lines to appropriate levels.
- Introduced env var to sharding support

**Testing**:
- A simple add operation works, which means the connection could be caught to the underlying database.
- When I tested with ab, apib the application hung up - due to the way we are using traversals in the current RDF based persistence models. It is known that this hung up will not happen in the proposed simpler data modelling.