### PR TITLE
OS#143 Introduce Neo4jID implementation

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
@@ -16,7 +16,7 @@ public abstract class DatabaseProvider {
 
 	public abstract Graph getGraphStore();
 
-	public abstract Neo4JGraph getNeo4JGraph();
+	public abstract <T> T getRawGraph();
 
 	public abstract void shutdown() throws Exception;
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/JanusGraphStorage.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/JanusGraphStorage.java
@@ -1,9 +1,5 @@
 package io.opensaber.registry.sink;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
-import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -12,6 +8,9 @@ import org.janusgraph.core.JanusGraphFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 public class JanusGraphStorage extends DatabaseProvider {
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/JanusGraphStorage.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/JanusGraphStorage.java
@@ -7,6 +7,7 @@ import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +16,7 @@ import org.springframework.core.env.Environment;
 public class JanusGraphStorage extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(JanusGraphStorage.class);
-	private Graph graph;
+	private JanusGraph graph;
 
 	public JanusGraphStorage(Environment environment) {
 		String graphFactory = environment.getProperty("database.janus_cassandra.graphFactory");
@@ -45,8 +46,8 @@ public class JanusGraphStorage extends DatabaseProvider {
 	}
 
 	@Override
-	public Neo4JGraph getNeo4JGraph() {
-		return null;
+	public JanusGraph getRawGraph() {
+		return graph;
 	}
 
 	@PostConstruct

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -1,8 +1,9 @@
 package io.opensaber.registry.sink;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import com.steelbridgelabs.oss.neo4j.structure.Neo4JElementIdProvider;
+import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
+import com.steelbridgelabs.oss.neo4j.structure.providers.Neo4JNativeElementIdProvider;
+import io.opensaber.registry.model.DBConnectionInfo;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Driver;
@@ -10,11 +11,8 @@ import org.neo4j.driver.v1.GraphDatabase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.steelbridgelabs.oss.neo4j.structure.Neo4JElementIdProvider;
-import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
-import com.steelbridgelabs.oss.neo4j.structure.providers.Neo4JNativeElementIdProvider;
-
-import io.opensaber.registry.model.DBConnectionInfo;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 public class Neo4jGraphProvider extends DatabaseProvider {
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -48,7 +48,7 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 
 	// TODO: We must have an abstract class to allow this possibility.
 	@Override
-	public Neo4JGraph getNeo4JGraph() {
+	public Neo4JGraph getRawGraph() {
 		return getGraph();
 	}
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jIdProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jIdProvider.java
@@ -7,9 +7,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class Neo4jIdProvider implements Neo4JElementIdProvider<String> {
-    public Neo4jIdProvider() {
-    }
-
     public String fieldName() {
         return null;
     }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jIdProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jIdProvider.java
@@ -1,0 +1,41 @@
+package io.opensaber.registry.sink;
+
+import com.steelbridgelabs.oss.neo4j.structure.Neo4JElementIdProvider;
+import org.neo4j.driver.v1.types.Entity;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class Neo4jIdProvider implements Neo4JElementIdProvider<String> {
+    public Neo4jIdProvider() {
+    }
+
+    public String fieldName() {
+        return null;
+    }
+
+    public String get(Entity entity) {
+        Objects.requireNonNull(entity, "entity cannot be null");
+        return String.valueOf(entity.id());
+    }
+
+    public String generate() {
+        return UUID.randomUUID().toString();
+    }
+
+    public String processIdentifier(Object id) {
+        Objects.requireNonNull(id, "Element identifier cannot be null");
+        if (id instanceof String) {
+            return (String)id;
+        } else {
+            throw new IllegalArgumentException(String.format("Expected an id that is convertible to Long but received %s", id.getClass()));
+        }
+    }
+
+    public String matchPredicateOperand(String alias) {
+        Objects.requireNonNull(alias, "alias cannot be null");
+        return alias + ".osid";
+    }
+}
+
+

--- a/java/registry/src/main/java/io/opensaber/registry/sink/OrientDBGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/OrientDBGraphProvider.java
@@ -1,9 +1,6 @@
 package io.opensaber.registry.sink;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
-import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
+import io.opensaber.registry.middleware.util.Constants;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph;
@@ -12,7 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 
-import io.opensaber.registry.middleware.util.Constants;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 public class OrientDBGraphProvider extends DatabaseProvider {
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/OrientDBGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/OrientDBGraphProvider.java
@@ -17,7 +17,7 @@ import io.opensaber.registry.middleware.util.Constants;
 public class OrientDBGraphProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(OrientDBGraphProvider.class);
-	private Graph graph;
+	private OrientGraph graph;
 
 	public OrientDBGraphProvider(Environment environment) {
 		String graphDbLocation = environment.getProperty(Constants.ORIENTDB_DIRECTORY);
@@ -33,8 +33,8 @@ public class OrientDBGraphProvider extends DatabaseProvider {
 	}
 
 	@Override
-	public Neo4JGraph getNeo4JGraph() {
-		return null;
+	public OrientGraph getRawGraph() {
+		return graph;
 	}
 
 	@PostConstruct

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -1,9 +1,5 @@
 package io.opensaber.registry.sink;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
-import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.structure.Graph;
@@ -11,6 +7,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 import org.umlg.sqlg.structure.SqlgGraph;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 public class SqlgProvider extends DatabaseProvider {
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -15,7 +15,7 @@ import org.umlg.sqlg.structure.SqlgGraph;
 public class SqlgProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(SqlgProvider.class);
-	private Graph graph;
+	private SqlgGraph graph;
 
 	public SqlgProvider(Environment environment) {
 		String jdbcUrl = environment.getProperty("database.jdbc.url");
@@ -34,8 +34,8 @@ public class SqlgProvider extends DatabaseProvider {
 	}
 
 	@Override
-	public Neo4JGraph getNeo4JGraph() {
-		return null;
+	public SqlgGraph getRawGraph() {
+		return graph;
 	}
 
 	@PostConstruct

--- a/java/registry/src/main/java/io/opensaber/registry/sink/TinkerGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/TinkerGraphProvider.java
@@ -13,7 +13,7 @@ import org.springframework.core.env.Environment;
 public class TinkerGraphProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(TinkerGraphProvider.class);
-	private Graph graph;
+	private TinkerGraph graph;
 	private Object environment;
 
 	public TinkerGraphProvider(Environment inputEnv) {
@@ -27,8 +27,8 @@ public class TinkerGraphProvider extends DatabaseProvider {
 	}
 
 	@Override
-	public Neo4JGraph getNeo4JGraph() {
-		return null;
+	public TinkerGraph getRawGraph() {
+		return graph;
 	}
 
 	@PostConstruct

--- a/java/registry/src/main/java/io/opensaber/registry/sink/TinkerGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/TinkerGraphProvider.java
@@ -1,14 +1,13 @@
 package io.opensaber.registry.sink;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
-import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 public class TinkerGraphProvider extends DatabaseProvider {
 

--- a/java/registry/src/main/java/io/opensaber/registry/util/TPGraphMain.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/TPGraphMain.java
@@ -2,6 +2,7 @@ package io.opensaber.registry.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
 import io.opensaber.pojos.OpenSaberInstrumentation;
 import io.opensaber.registry.exception.EncryptionException;
 import io.opensaber.registry.middleware.util.LogMarkers;
@@ -147,7 +148,8 @@ public class TPGraphMain {
         Map map = new HashMap();
         Graph graph = dbProvider.getGraphStore();
         Transaction tx = graph.tx();
-        StatementResult sr = dbProvider.getNeo4JGraph().execute("match (n) where n.osid='" + osid + "' return n");
+        Neo4JGraph neo4JGraph = dbProvider.getRawGraph();
+        StatementResult sr = neo4JGraph.execute("match (n) where n.osid='" + osid + "' return n");
         while(sr.hasNext()){
             Record record = sr.single();
             InternalNode internalNode = (InternalNode) record.get("n").asNode();


### PR DESCRIPTION
We have been relying on java.util.UUID to provide unique identifiers to the records created. While this is explicit, at least in Neo4j there is a clear easy way to setup id. It is believed that by this method, our reads and searches using ID can also become faster. Just compare this with the current model of loading all the vertices and then doing a client side filtering. We found that this way is patheticallyy slow for databases having more nodes.
As part of this PR, I've just introduced the id provider implementation - not used it. There is a need to refactor some registryDaoImpl code to ensure this scheme of generating ids works for all type of databases. So consider this just "part1".
Since no functionality has been modified, just ensured the tests pass.