### PR TITLE
OS-141 Initial base classes to support parent grouping

### DIFF
--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -423,6 +423,15 @@
                 </configuration>
             </plugin>
         </plugins>
+
+        <testResources>
+        <testResource>
+            <directory>${project.basedir}/src/test/resources</directory>
+        </testResource>
+        <testResource>
+            <directory>${project.basedir}/src/main/resources</directory>
+        </testResource>
+        </testResources>
     </build>
 
 

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -273,24 +273,23 @@ public class GenericConfiguration implements WebMvcConfigurer {
 		requestFactory.setReadTimeout(readTimeout);
 		return new RestTemplate(requestFactory);
 	}
-	@Bean 
+	@Bean
 	public DBProviderFactory dbProviderFactory(){
 		return new DBProviderFactory();
 	}
-	
-	@Bean 
+
+	@Bean
 	public DBConnectionInfoMgr dBConnectionInfoMgr(){
 		return new DBConnectionInfoMgr();
 	}
-	
+
 	@Bean
 	public IShardAdvisor shardAdvisor() throws IOException{
 		ShardAdvisor shardAdvisor = new ShardAdvisor();
-		DBConnectionInfoMgr connectionInforMgr = dBConnectionInfoMgr();
-		shardAdvisor.registerAdvisor(connectionInforMgr.getShardProperty(), new SerialNumberShardAdvisor(connectionInforMgr));
-		return shardAdvisor.getShardAdvisor(connectionInforMgr.getShardProperty());	
+		DBConnectionInfoMgr dbConnectionInfoMgr = dBConnectionInfoMgr();
+		shardAdvisor.registerAdvisor(dbConnectionInfoMgr.getShardProperty(), new SerialNumberShardAdvisor(dbConnectionInfoMgr));
+		return shardAdvisor.getShardAdvisor(dbConnectionInfoMgr.getShardProperty());
 	}
-
 
 	@Bean
 	public UrlValidator urlValidator() {

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -367,7 +367,8 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	@Bean
 	public Vertex parentVertex() {
 		Graph g = databaseProvider().getGraphStore();
-		Vertex parentV = TPGraphMain.createParentVertex(g);
+		// TODO: this label is temporal and will be removed.
+		Vertex parentV = TPGraphMain.createParentVertex(g, "Persons");
 		try {
 			g.close();
 		} catch (Exception e) {

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -321,7 +321,8 @@ public class RegistryController {
 	
 	private Vertex parentVertex(DatabaseProvider databaseProvider) {		
 		Graph g = databaseProvider.getGraphStore();
-		Vertex parentV = TPGraphMain.createParentVertex(g);
+		// TODO: Apply default grouping - to be removed.
+		Vertex parentV = TPGraphMain.createParentVertex(g, "Persons");
 		try {
 			g.close();
 		} catch (Exception e) {

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -1,42 +1,9 @@
 package io.opensaber.registry.controller;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
-import io.opensaber.pojos.APIMessage;
-import io.opensaber.pojos.HealthCheckResponse;
-import io.opensaber.pojos.OpenSaberInstrumentation;
-import io.opensaber.pojos.Response;
-import io.opensaber.pojos.ResponseParams;
+import io.opensaber.pojos.*;
 import io.opensaber.registry.exception.AuditFailedException;
 import io.opensaber.registry.exception.EntityCreationException;
 import io.opensaber.registry.exception.RecordNotFoundException;
@@ -52,13 +19,28 @@ import io.opensaber.registry.service.RegistryService;
 import io.opensaber.registry.service.SearchService;
 import io.opensaber.registry.shard.advisory.ShardManager;
 import io.opensaber.registry.sink.DatabaseProvider;
-import io.opensaber.registry.transform.Configuration;
-import io.opensaber.registry.transform.ConfigurationHelper;
-import io.opensaber.registry.transform.Data;
-import io.opensaber.registry.transform.ITransformer;
-import io.opensaber.registry.transform.TransformationException;
-import io.opensaber.registry.transform.Transformer;
+import io.opensaber.registry.transform.*;
 import io.opensaber.registry.util.TPGraphMain;
+import org.apache.jena.rdf.model.Model;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 public class RegistryController {

--- a/java/registry/src/main/java/io/opensaber/registry/model/DBConnectionInfoMgr.java
+++ b/java/registry/src/main/java/io/opensaber/registry/model/DBConnectionInfoMgr.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
  * Auto populates/binds the field values from yaml properties.
  *
  */
-@Component
+@Component("dbConnectionInfoMgr")
 @ConfigurationProperties(prefix = "database")
 public class DBConnectionInfoMgr {
 	

--- a/java/registry/src/main/java/io/opensaber/registry/shard/advisory/ShardManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/shard/advisory/ShardManager.java
@@ -16,7 +16,7 @@ import io.opensaber.registry.sink.DatabaseProvider;
 public class ShardManager {
 	
 	@Autowired
-	private DBConnectionInfoMgr dBConnectionInfoMgr;
+	private DBConnectionInfoMgr dbConnectionInfoMgr;
 	@Autowired
 	private DBProviderFactory dbProviderFactory;
 	@Autowired
@@ -41,7 +41,7 @@ public class ShardManager {
 	}
 
 	public String getShardProperty() {
-		return dBConnectionInfoMgr.getShardProperty();
+		return dbConnectionInfoMgr.getShardProperty();
 	}
 
 	public DatabaseProvider getDatabaseProvider(){

--- a/java/registry/src/main/java/io/opensaber/registry/sink/DBProviderFactory.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DBProviderFactory.java
@@ -1,29 +1,28 @@
 package io.opensaber.registry.sink;
 
-import java.io.IOException;
-
+import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.model.DBConnectionInfo;
+import io.opensaber.registry.model.DBConnectionInfoMgr;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
-
-import io.opensaber.registry.middleware.util.Constants;
-import io.opensaber.registry.model.DBConnectionInfo;
 
 @Component("dbProviderFactory")
 public class DBProviderFactory {
 	
 	@Autowired
 	Environment environment;
-		
-	public DatabaseProvider getInstance(DBConnectionInfo connectionInfo) throws IOException{
+
+	@Autowired
+	DBConnectionInfoMgr dbConnectionInfoMgr;
+	
+	public DatabaseProvider getInstance(DBConnectionInfo connectionInfo) {
 		String dbProvider = environment.getProperty(Constants.DATABASE_PROVIDER);
 		DatabaseProvider provider;
 		if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.ORIENTDB.getName())) {
 			provider = new OrientDBGraphProvider(environment);
 			provider.initializeGlobalGraphConfiguration();
-		} else if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.NEO4J.getName())) {			
-			if(connectionInfo == null)
-				throw new IOException("No shard is configured. Please configure a shard");
+		} else if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.NEO4J.getName())) {
 			provider = new Neo4jGraphProvider(connectionInfo);
 		} else if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.SQLG.getName())) {
 			provider = new SqlgProvider(environment);

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
@@ -1,0 +1,37 @@
+package io.opensaber.registry.util;
+
+import io.opensaber.registry.middleware.util.LogMarkers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component("definitionsManager")
+public class DefinitionsManager {
+    private static Logger logger = LoggerFactory.getLogger(DefinitionsManager.class);
+
+    @Autowired
+    private DefinitionsReader definitionsReader;
+    private Map<String, Resource> definitionResourceMap = new HashMap<String, Resource>();
+
+    // Loads the definitions from the _schemas folder
+    public Set<String> getAllKnownDefinitions() {
+        if (definitionResourceMap.isEmpty()) {
+            try {
+                Resource[] resources = definitionsReader.getResources("classpath:public/_schemas/*.json");
+                for (Resource resource : resources) {
+                    definitionResourceMap.put(resource.getFilename(), resource);
+                }
+            } catch (IOException ioe) {
+                logger.error(LogMarkers.FATAL, "Cannot load json resources. Validation can't work");
+            }
+        }
+        return definitionResourceMap.keySet();
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsReader.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsReader.java
@@ -1,0 +1,34 @@
+package io.opensaber.registry.util;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Loads any given pattern of resources
+ *
+ */
+@Component("definitionsReader")
+public class DefinitionsReader {
+    private ResourceLoader resourceLoader;
+
+    @Autowired
+    public DefinitionsReader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    /**
+     * Loads the resources with a given pattern
+     * @param pattern "Example: *.json to load all json files"
+     * @return
+     * @throws IOException
+     */
+    public Resource[] getResources(String pattern) throws IOException {
+        Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(resourceLoader).getResources(pattern);
+        return resources;
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -20,15 +20,19 @@ public class EntityParenter {
     private Set<String> defintionNames;
     private List<DBConnectionInfo> dbConnectionInfoList;
 
-    @Autowired
-    public EntityParenter(DefinitionsManager definitionsManager, DBConnectionInfoMgr dbConnectionInfoMgr) {
-        defintionNames = definitionsManager.getAllKnownDefinitions();
-        dbConnectionInfoList = dbConnectionInfoMgr.getConnectionInfo();
-    }
     /**
      * Holds information about a definition and a list of ShardParents
      */
     private HashMap<String, ShardParentInfoList> definitionShardParentMap;
+
+    @Autowired
+    public EntityParenter(DefinitionsManager definitionsManager, DBConnectionInfoMgr dbConnectionInfoMgr) {
+        this.definitionsManager = definitionsManager;
+        this.dbConnectionInfoMgr = dbConnectionInfoMgr;
+
+        defintionNames = definitionsManager.getAllKnownDefinitions();
+        dbConnectionInfoList = dbConnectionInfoMgr.getConnectionInfo();
+    }
 
     /**
      * Creates the parent vertex in all the shards for all default definitions

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -13,15 +13,18 @@ import java.util.Set;
 
 @Component("entityParenter")
 public class EntityParenter {
-    @Autowired
-    private DefinitionsManager definitionsManager;
 
-    @Autowired
+    private DefinitionsManager definitionsManager;
     private DBConnectionInfoMgr dbConnectionInfoMgr;
 
-    private Set<String> defintionNames = definitionsManager.getAllKnownDefinitions();
-    private List<DBConnectionInfo> dbConnectionInfoList = dbConnectionInfoMgr.getConnectionInfo();
+    private Set<String> defintionNames;
+    private List<DBConnectionInfo> dbConnectionInfoList;
 
+    @Autowired
+    public EntityParenter(DefinitionsManager definitionsManager, DBConnectionInfoMgr dbConnectionInfoMgr) {
+        defintionNames = definitionsManager.getAllKnownDefinitions();
+        dbConnectionInfoList = dbConnectionInfoMgr.getConnectionInfo();
+    }
     /**
      * Holds information about a definition and a list of ShardParents
      */

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -1,0 +1,74 @@
+package io.opensaber.registry.util;
+
+import io.opensaber.registry.model.DBConnectionInfo;
+import io.opensaber.registry.model.DBConnectionInfoMgr;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Component("entityParenter")
+public class EntityParenter {
+    @Autowired
+    private DefinitionsManager definitionsManager;
+
+    @Autowired
+    private DBConnectionInfoMgr dbConnectionInfoMgr;
+
+    private Set<String> defintionNames = definitionsManager.getAllKnownDefinitions();
+    private List<DBConnectionInfo> dbConnectionInfoList = dbConnectionInfoMgr.getConnectionInfo();
+
+    /**
+     * Holds information about a definition and a list of ShardParents
+     */
+    private HashMap<String, ShardParentInfoList> definitionShardParentMap;
+
+    /**
+     * Creates the parent vertex in all the shards for all default definitions
+     * @return
+     */
+    public Optional<String> createKnownParenters(Graph graph) {
+        Optional<String> result;
+        String msg = null;
+
+        dbConnectionInfoList.forEach(dbConnectionInfo -> {
+            // Get the shard
+
+            defintionNames.forEach(defintionName -> {
+                String parentLabel = ParentLabelGenerator.getLabel(defintionName);
+                TPGraphMain.createParentVertex(graph, parentLabel);
+            });
+        });
+
+        result = Optional.of(msg);
+        return result;
+    }
+
+    /**
+     * Reads the database and learns the mappings. This is expected to be called
+     * just once.
+     * @return
+     */
+    public void identifyDefinitionParents() {
+        defintionNames.forEach(defintionName -> {
+        // Create the vertex with label if not already found
+            ShardParentInfoList parentInfoList = new ShardParentInfoList();
+
+            dbConnectionInfoList.forEach(dbConnectionInfo -> {
+                // TODO
+                // Get the shard and fetch uuid from label
+
+                String shardId = "";
+                String uuid = "";
+                parentInfoList.getParentInfos().add(new ShardParentInfo(shardId, uuid));
+            });
+
+            definitionShardParentMap.put(defintionName, parentInfoList);
+        });
+    }
+
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/ParentLabelGenerator.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ParentLabelGenerator.java
@@ -1,0 +1,12 @@
+package io.opensaber.registry.util;
+
+/**
+ * For a given entity type, defines the parent label.
+ */
+public class ParentLabelGenerator {
+    private static String SUFFIX = "_GROUP";
+
+    public static String getLabel(String entityType) {
+        return entityType + SUFFIX;
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/ShardParentInfo.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ShardParentInfo.java
@@ -1,0 +1,27 @@
+package io.opensaber.registry.util;
+
+public class ShardParentInfo {
+    private String shardId;
+    private String uuid;
+
+    public ShardParentInfo(String shardId, String uuid) {
+        this.shardId = shardId;
+        this.uuid = uuid;
+    }
+
+    public String getShardId() {
+        return shardId;
+    }
+
+    public void setShardId(String shardId) {
+        this.shardId = shardId;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/ShardParentInfoList.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ShardParentInfoList.java
@@ -1,0 +1,16 @@
+package io.opensaber.registry.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShardParentInfoList {
+    private List<ShardParentInfo> parentInfos = new ArrayList<>();
+
+    public List<ShardParentInfo> getParentInfos() {
+        return parentInfos;
+    }
+
+    public void setParentInfos(List<ShardParentInfo> parentInfos) {
+        this.parentInfos = parentInfos;
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/TPGraphMain.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/TPGraphMain.java
@@ -80,16 +80,14 @@ public class TPGraphMain {
         return v1.addEdge(label, v2);
     }
 
-    public static Vertex createParentVertex(Graph graph) {
-        String personsStr = "Persons";
-        String personsId = "ParentEntity_Persons";
+    public static Vertex createParentVertex(Graph graph, String parentLabel) {
         GraphTraversalSource gtRootTraversal = graph.traversal();
-        GraphTraversal<Vertex, Vertex> rootVertex = gtRootTraversal.V().hasLabel(personsStr);
+        GraphTraversal<Vertex, Vertex> rootVertex = gtRootTraversal.V().hasLabel(parentLabel);
         Vertex parentVertex = null;
         if (!rootVertex.hasNext()) {
-            parentVertex = graph.addVertex(personsStr);
-            parentVertex.property("id", personsId);
-            parentVertex.property("label", personsStr);
+            parentVertex = graph.addVertex(parentLabel);
+            // TODO: this could be parentVertex.id() after we make our own Neo4jIdProvider
+            parentVertex.property("osid", parentLabel + "osid");
         } else {
             parentVertex = rootVertex.next();
         }

--- a/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsManagerTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsManagerTest.java
@@ -1,0 +1,38 @@
+package io.opensaber.registry.util;
+
+import io.opensaber.registry.middleware.util.Constants;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {DefinitionsReader.class, DefinitionsManager.class})
+@ActiveProfiles(Constants.TEST_ENVIRONMENT)
+public class DefinitionsManagerTest {
+
+    @Autowired
+    private DefinitionsManager definitionsManager;
+
+    @Autowired
+    private DefinitionsReader definitionsReader;
+
+    @Test
+    public void testIfResourcesCountMatchesFileDefinitions() {
+        boolean flag = false;
+        try {
+            int nDefinitions = definitionsManager.getAllKnownDefinitions().size();
+            int nResources = definitionsReader.getResources("classpath:public/_schemas/*.json").length;
+            flag = (nDefinitions == nResources);
+        } catch (IOException ioe) {
+
+        }
+        assertTrue(flag);
+    }
+}

--- a/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
@@ -1,0 +1,41 @@
+package io.opensaber.registry.util;
+
+import io.opensaber.registry.middleware.util.Constants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {DefinitionsReader.class})
+@ActiveProfiles(Constants.TEST_ENVIRONMENT)
+public class DefinitionsReaderTest {
+    @Autowired
+    private DefinitionsReader definitionsReader;
+
+    @BeforeClass
+    public static void setUp() {
+
+    }
+
+    @Test
+    public void whenAtLeastOneDefinitionPresent_Then_ok() {
+        Resource[] resources = null;
+        try {
+            resources = definitionsReader.getResources("classpath:public/_schemas/*.json");
+        } catch (IOException ioe) {
+            assertFalse(true);
+        }
+        assertTrue("At least one definition must be present", resources.length >= 1);
+    }
+}

--- a/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
@@ -1,7 +1,6 @@
 package io.opensaber.registry.util;
 
 import io.opensaber.registry.middleware.util.Constants;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
@@ -7,7 +7,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -23,11 +22,6 @@ public class DefinitionsReaderTest {
     @Autowired
     private DefinitionsReader definitionsReader;
 
-    @BeforeClass
-    public static void setUp() {
-
-    }
-
     @Test
     public void whenAtLeastOneDefinitionPresent_Then_ok() {
         Resource[] resources = null;
@@ -36,6 +30,6 @@ public class DefinitionsReaderTest {
         } catch (IOException ioe) {
             assertFalse(true);
         }
-        assertTrue("At least one definition must be present", resources.length >= 1);
+        assertTrue("At least one definition must be present", resources != null && resources.length >= 1);
     }
 }


### PR DESCRIPTION
This forms the basis of normalizing our database layouts. Rather than making independent tables for each entity, parenting the entity makes them fall under one table, that is more manageable and is much friendly for other extensible works.
There are several TODOs here to get it working end-to-end, but I expect them to be fillers and not major work. Putting this up for an earlier review. No present functionality is affected.
@pritha-tarento - I'd like you to start doing this filler implementation please.