### PR TITLE
OS-153 Add postgres support

### DIFF
--- a/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
+++ b/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
@@ -1,9 +1,8 @@
 package io.opensaber.validators;
 
-import io.opensaber.pojos.APIMessage;
 import io.opensaber.registry.middleware.MiddlewareHaltException;
 
 public interface IValidate {
 
-	public boolean validate(String objString, String entityType) throws MiddlewareHaltException;
+	boolean validate(String entityType, String payload) throws MiddlewareHaltException;
 }

--- a/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/ValidationFilter.java
+++ b/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/ValidationFilter.java
@@ -1,11 +1,10 @@
 package io.opensaber.validators;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import io.opensaber.pojos.APIMessage;
 import io.opensaber.registry.middleware.Middleware;
 import io.opensaber.registry.middleware.MiddlewareHaltException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class ValidationFilter implements Middleware {
@@ -23,7 +22,7 @@ public class ValidationFilter implements Middleware {
 	public boolean execute(APIMessage apiMessage) throws MiddlewareHaltException {
 		String entityType = apiMessage.getRequest().getEntityType();
 		String payload = apiMessage.getRequest().getRequestMapAsString();
-		if(!validationService.validate(entityType, payload)){
+		if (!validationService.validate(entityType, payload)) {
 			throw new MiddlewareHaltException(VALIDATION_FAILURE_MSG);
 		}
 		return true;

--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -225,11 +225,12 @@
             <artifactId>sqlg-h2-dialect</artifactId>
             <version>1.5.0</version>
         </dependency>
-        <!--
+
+        <!-- Include this dependency for Postgres support -->
 		<dependency>
 			<groupId>org.umlg</groupId>
 			<artifactId>sqlg-postgres</artifactId>
-			<version>1.5.1</version>
+			<version>1.5.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -237,7 +238,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		-->
+        <!-- End dependency for Postgres support -->
 
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -282,7 +282,7 @@ public class RegistryController {
 			response.setResult(result);
 			responseParams.setStatus(Response.Status.SUCCESSFUL);
 			watch.stop("RegistryController.addToExistingEntity");
-			logger.debug("RegistryController : Entity with label {} added !", "");
+			logger.debug("RegistryController : Entity {} added !", resultId);
 		} catch (Exception e) {
 			logger.error("Exception in controller while adding entity !", e);
 			response.setResult(result);
@@ -325,24 +325,6 @@ public class RegistryController {
 		keyToPurge.add(JsonldConstants.TYPE);
 		return keyToPurge;
 
-	}
-
-	private Vertex parentVertex() {
-		Vertex parentV = null;
-		try {
-			DatabaseProvider databaseProvider = databaseProviderWrapper.getDatabaseProvider();
-			Graph g = databaseProvider.getGraphStore();
-
-			// TODO: Apply default grouping - to be removed.
-			Transaction tx = databaseProvider.startTransaction(g);
-			parentV = new TPGraphMain().ensureParentVertex(g, "Teacher_GROUP");
-			databaseProvider.commitTransaction(g, tx);
-
-		} catch (Exception e) {
-			logger.info(e.getMessage());
-		}
-
-		return parentV;
 	}
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/CustomGraph.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/CustomGraph.java
@@ -1,4 +1,0 @@
-package io.opensaber.registry.sink;
-
-public class CustomGraph {
-}

--- a/java/registry/src/main/java/io/opensaber/registry/sink/CustomGraph.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/CustomGraph.java
@@ -1,0 +1,4 @@
+package io.opensaber.registry.sink;
+
+public class CustomGraph {
+}

--- a/java/registry/src/main/java/io/opensaber/registry/sink/DBProviderFactory.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DBProviderFactory.java
@@ -23,6 +23,7 @@ public class DBProviderFactory {
 	public DatabaseProvider getInstance(DBConnectionInfo connectionInfo) {
 		DatabaseProvider provider = null;
 		String dbProvider = environment.getProperty(Constants.DATABASE_PROVIDER);
+		String uuidPropertyName = dbConnectionInfoMgr.getUuidPropertyName();
 
 		// In tests, we use TinkerGraph presently.
 		if (!dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.TINKERGRAPH.getName()) &&
@@ -33,9 +34,9 @@ public class DBProviderFactory {
 				provider = new OrientDBGraphProvider(environment);
 				provider.initializeGlobalGraphConfiguration();
 			} else if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.NEO4J.getName())) {
-				provider = new Neo4jGraphProvider(connectionInfo);
+				provider = new Neo4jGraphProvider(connectionInfo, uuidPropertyName);
 			} else if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.SQLG.getName())) {
-				provider = new SqlgProvider(connectionInfo);
+				provider = new SqlgProvider(connectionInfo, uuidPropertyName);
 				provider.initializeGlobalGraphConfiguration();
 			} else if (dbProvider.equalsIgnoreCase(Constants.GraphDatabaseProvider.TINKERGRAPH.getName())) {
 				provider = new TinkerGraphProvider(environment);

--- a/java/registry/src/main/java/io/opensaber/registry/sink/JanusGraphStorage.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/JanusGraphStorage.java
@@ -2,7 +2,6 @@ package io.opensaber.registry.sink;
 
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphFactory;
 import org.slf4j.Logger;
@@ -16,6 +15,7 @@ public class JanusGraphStorage extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(JanusGraphStorage.class);
 	private JanusGraph graph;
+	private OSGraph osGraph;
 
 	public JanusGraphStorage(Environment environment) {
 		String graphFactory = environment.getProperty("database.janus_cassandra.graphFactory");
@@ -37,16 +37,13 @@ public class JanusGraphStorage extends DatabaseProvider {
 		config.setProperty("cache.db-cache-size", Float.parseFloat(dbCacheSize));
 		config.setProperty("cache.db-cache-clean-wait", Integer.parseInt(dbCacheCleanUpWaitTime));
 		graph = JanusGraphFactory.open(config);
+		osGraph = new OSGraph(graph, false);
 	}
 
-	@Override
-	public Graph getGraphStore() {
-		return graph;
-	}
 
 	@Override
-	public JanusGraph getRawGraph() {
-		return graph;
+	public OSGraph getOSGraph() {
+		return osGraph;
 	}
 
 	@PostConstruct

--- a/java/registry/src/main/java/io/opensaber/registry/sink/OSGraph.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/OSGraph.java
@@ -1,0 +1,27 @@
+package io.opensaber.registry.sink;
+
+import org.apache.tinkerpop.gremlin.structure.Graph;
+
+public class OSGraph implements AutoCloseable {
+    private Graph graph;
+    private boolean closeRequired;
+
+    protected OSGraph() {}
+
+    public OSGraph (Graph g, boolean close) {
+        graph = g;
+        closeRequired = close;
+    }
+
+    public void close() throws Exception {
+        if (closeRequired) {
+            graph.close();
+        } else {
+            // no action required.
+        }
+    }
+
+    public Graph getGraphStore() {
+        return this.graph;
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/sink/OrientDBGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/OrientDBGraphProvider.java
@@ -1,6 +1,7 @@
 package io.opensaber.registry.sink;
 
 import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.transform.Data;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph;
@@ -16,6 +17,7 @@ public class OrientDBGraphProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(OrientDBGraphProvider.class);
 	private OrientGraph graph;
+	private OSGraph customGraph;
 
 	public OrientDBGraphProvider(Environment environment) {
 		String graphDbLocation = environment.getProperty(Constants.ORIENTDB_DIRECTORY);
@@ -23,16 +25,7 @@ public class OrientDBGraphProvider extends DatabaseProvider {
 		config.setProperty(OrientGraph.CONFIG_URL, String.format("embedded:%s", graphDbLocation));
 		config.setProperty(OrientGraph.CONFIG_TRANSACTIONAL, true);
 		graph = OrientGraph.open(config);
-	}
-
-	@Override
-	public Graph getGraphStore() {
-		return graph;
-	}
-
-	@Override
-	public OrientGraph getRawGraph() {
-		return graph;
+		customGraph = new OSGraph(graph, false);
 	}
 
 	@PostConstruct
@@ -48,5 +41,10 @@ public class OrientDBGraphProvider extends DatabaseProvider {
 		logger.info("Gracefully shutting down OrientGraph DB instance ...");
 		logger.info("**************************************************************************");
 		graph.close();
+	}
+
+	@Override
+	public OSGraph getOSGraph() {
+		return customGraph;
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -1,36 +1,30 @@
 package io.opensaber.registry.sink;
 
 import io.opensaber.registry.model.DBConnectionInfo;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.umlg.sqlg.structure.SqlgGraph;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 public class SqlgProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(SqlgProvider.class);
 	private SqlgGraph graph;
+	private OSGraph customGraph;
 
-	public SqlgProvider(DBConnectionInfo connectionInfo) {
+	public SqlgProvider(DBConnectionInfo connectionInfo, String uuidPropertyName) {
 		Configuration config = new BaseConfiguration();
 		config.setProperty("jdbc.url", connectionInfo.getUri());
 		config.setProperty("jdbc.username", connectionInfo.getUsername());
 		config.setProperty("jdbc.password", connectionInfo.getPassword());
+		setUuidPropertyName(uuidPropertyName);
 		graph = SqlgGraph.open(config);
-	}
-
-	@Override
-	public Graph getGraphStore() {
-		return graph;
-	}
-
-	@Override
-	public SqlgGraph getRawGraph() {
-		return graph;
+		customGraph = new OSGraph(graph, false);
 	}
 
 	@PostConstruct
@@ -48,4 +42,13 @@ public class SqlgProvider extends DatabaseProvider {
 		graph.close();
 	}
 
+	@Override
+	public OSGraph getOSGraph() {
+		return customGraph;
+	}
+
+	@Override
+	public String getId(Vertex vertex) {
+		return (String) vertex.property(getUuidPropertyName()).value();
+	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/TinkerGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/TinkerGraphProvider.java
@@ -1,6 +1,5 @@
 package io.opensaber.registry.sink;
 
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,21 +12,13 @@ public class TinkerGraphProvider extends DatabaseProvider {
 
 	private Logger logger = LoggerFactory.getLogger(TinkerGraphProvider.class);
 	private TinkerGraph graph;
+	private OSGraph osGraph;
 	private Object environment;
 
 	public TinkerGraphProvider(Environment inputEnv) {
 		graph = TinkerGraph.open();
+		osGraph = new OSGraph(graph, false);
 		environment = inputEnv;
-	}
-
-	@Override
-	public Graph getGraphStore() {
-		return graph;
-	}
-
-	@Override
-	public TinkerGraph getRawGraph() {
-		return graph;
 	}
 
 	@PostConstruct
@@ -43,5 +34,10 @@ public class TinkerGraphProvider extends DatabaseProvider {
 		logger.info("Gracefully shutting down TinkerGraphDatabaseFactory instance ...");
 		logger.info("**************************************************************************");
 		graph.close();
+	}
+
+	@Override
+	public OSGraph getOSGraph() {
+		return osGraph;
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -5,6 +5,7 @@ import io.opensaber.registry.model.DBConnectionInfo;
 import io.opensaber.registry.model.DBConnectionInfoMgr;
 import io.opensaber.registry.sink.DBProviderFactory;
 import io.opensaber.registry.sink.DatabaseProvider;
+import io.opensaber.registry.sink.OSGraph;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -57,8 +58,8 @@ public class EntityParenter {
             logger.info("Starting to parents for {} definitions in shard {}", defintionNames.size(), dbConnectionInfo.getShardId());
             DatabaseProvider dbProvider = dbProviderFactory.getInstance(dbConnectionInfo);
             try {
-                try (Graph graph = dbProvider.getGraphStore()) {
-
+                try (OSGraph osGraph = dbProvider.getOSGraph()) {
+                    Graph graph = osGraph.getGraphStore();
                     List<ShardParentInfo> shardParentInfoList = new ArrayList<>();
                     try (Transaction tx = dbProvider.startTransaction(graph)) {
 

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -39,25 +39,40 @@ database:
   #       existing data in the database.
   uuidPropertyName: ${database_uuidPropertyName:osid}
 
-  # Providers available are NEO4J, SQLG, TINKERGRAPH, CASSANDRA, ORIENTDB.
+  # Providers available are NEO4J, SQLG, CASSANDRA, ORIENTDB, TINKERGRAPH (in-memory).
   # NOTE: Values given against 'shardId' must be unique
-  provider: ${database_provider:NEO4J}
+  provider: ${database_provider:SQLG}
 
   # Choose "none" as the propertyName if you don't want any shards. Otherwise
   # implement IShardAdvisor interface in your own ways. An example, SerialNumShardAdvisor
   # has been provided for reference. If you'd like to use it, set value "serialNum" here.
+  # Note that "serialNum" must then be part of the payload.
   shardProperty: ${database_shardProperty:none}
+
   connectionInfo:
     -
+      # shardId must be a unique identifier to each connection.
       shardId: shard1
-      uri: ${connectionInfo_uri:bolt://localhost:7687}
+
+      # The format of the URI can be learnt from the following links -
+      #     * 1. Graph database (Neo4J)
+      #     ** https://github.com/SteelBridgeLabs/neo4j-gremlin-bolt
+      #     ** Example : bolt://localhost:7687
+      #     * 2. Relational databases (Postgresql, HSQLDB, H2, MariaDB, MySQL, MSSQLServer)
+      #     ** http://sqlg.org/docs/2.0.0-SNAPSHOT/
+      #     ** Example - Postgres - jdbc:postgresql://localhost:5432/yourdb
+      uri: ${connectionInfo_uri:jdbc:postgresql://localhost:5432/json2tp}
+
       username: ${connectionInfo_username:neo4j}
       password: ${connectionInfo_password:}
-    -
-      shardId: shard2
-      uri: ${connectionInfo_uri:bolt://localhost:7688}
-      username: ${connectionInfo_username:neo4j}
-      password: ${connectionInfo_password:}
+
+      # Any other shard information follows...
+
+    #-
+      #shardId: shard2
+      #uri: ${connectionInfo_uri:bolt://localhost:7688}
+      #username: ${connectionInfo_username:neo4j}
+      #password: ${connectionInfo_password:}
 
 ##################################################################################
 # Uncomment the following section to use Cassandra as backend store              #

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -41,7 +41,7 @@ database:
 
   # Providers available are NEO4J, SQLG, CASSANDRA, ORIENTDB, TINKERGRAPH (in-memory).
   # NOTE: Values given against 'shardId' must be unique
-  provider: ${database_provider:SQLG}
+  provider: ${database_provider:NEO4J}
 
   # Choose "none" as the propertyName if you don't want any shards. Otherwise
   # implement IShardAdvisor interface in your own ways. An example, SerialNumShardAdvisor
@@ -61,7 +61,7 @@ database:
       #     * 2. Relational databases (Postgresql, HSQLDB, H2, MariaDB, MySQL, MSSQLServer)
       #     ** http://sqlg.org/docs/2.0.0-SNAPSHOT/
       #     ** Example - Postgres - jdbc:postgresql://localhost:5432/yourdb
-      uri: ${connectionInfo_uri:jdbc:postgresql://localhost:5432/json2tp}
+      uri: ${connectionInfo_uri:bolt://localhost:7687}
 
       username: ${connectionInfo_username:neo4j}
       password: ${connectionInfo_password:}

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -61,7 +61,7 @@ public class JsonValidationServiceImpl implements IValidate {
 	}
 
 	@Override
-	public boolean validate(String objString, String entityType) throws MiddlewareHaltException {
+	public boolean validate(String entityType, String objString) throws MiddlewareHaltException {
 		boolean result = false;
 		Schema schema = getEntitySchema(entityType);
 		JSONObject obj = new JSONObject(objString);


### PR DESCRIPTION
The Autocloseable interface on the generic Graph causes dangers of closing it accidentally, in case of SQLG support (that brings Postgres). I've wrapped the Graph under a "OSGraph" and used that throughout.
The id generation in SQLG is not present - raised https://github.com/pietermartin/sqlg/issues/324
I tried with custom id generation and reading in the DatabaseProvider classes; Finally got a runtime exception that "RecordId" must be of Long type. This is documented in the SQLG help but missed my eyes unfortunately. Moreover, we need this only for read ops. I'd like them to be as-is unused for now and will take care to delete it depending on the SQLG.
Passed uuidPropertyName to the specific database providers (they are 'new' instantiated and so Spring annotations cease to work).