### PR TITLE
Issue #OS-154 Fix for api id verification

### DIFF
--- a/java/registry-interceptor/src/main/java/io/opensaber/registry/interceptor/RequestIdValidationInterceptor.java
+++ b/java/registry-interceptor/src/main/java/io/opensaber/registry/interceptor/RequestIdValidationInterceptor.java
@@ -38,7 +38,7 @@ public class RequestIdValidationInterceptor implements HandlerInterceptor {
 		RequestWrapper wrapper = apiMessage.getRequestWrapper();
 		String expectedAPI = requestIdMap.getOrDefault(wrapper.getRequestURI(), "");
 
-		return !expectedAPI.isEmpty();
+		return !expectedAPI.isEmpty() && (apiMessage.getRequest().getId().compareTo(expectedAPI) == 0);
 	}
 
 }

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -108,7 +108,7 @@
         <appender-ref ref="RegistryAuditAppender"/>
     </logger>
 
-    <root level="DEBUG" additivity="FALSE">
+    <root level="INFO" additivity="FALSE">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>
     </root>

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -73,6 +73,7 @@ public class JsonValidationServiceImpl implements IValidate {
 			e.getCausingExceptions().stream()
 					.map(ValidationException::getMessage)
 					.forEach(logger::error);
+			throw new MiddlewareHaltException(e.getMessage());
 		}
 		return result;
 	}


### PR DESCRIPTION
The api id was not compared with what came from the payload; it was just checked if it is a recognized one incorrectly.
The log info is changed to INFO for the codebase in prep to 2.0.0RC1 drop
In case, there is a validation failure, it is better that the validation message is passed back to the caller and not withheld. I've temporarily introduced a runtime exception and would like to re-look at Exception handling as a whole post 2.0.0 drop. Till then, please bear with this.