### PR TITLE
Issue OS-138 code change for sign api which is used for signing entit…

### DIFF
--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -11,6 +11,8 @@ public class Constants {
 	public static final String REQUEST_OBJECT = "requestObject";
 	public static final String RDF_OBJECT = "rdfObject";
 	public static final String CONTROLLER_INPUT = "controllerInput";
+	public static final String SIGN_ENTITY = "entity";
+	public static final String SIGN_VALUE = "value";
 
 	public static final String LD_OBJECT = "ldObject";
 	public static final String METHOD_ORIGIN = "methodOrigin";

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryUtilsController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryUtilsController.java
@@ -62,10 +62,9 @@ public class RegistryUtilsController {
 		try {
 			watch.start("RegistryUtilsController.generateSignature");
 			Map<String, Object> requestBodyMap = apiMessage.getRequest().getRequestMap();
-			if (requestBodyMap.containsKey(Constants.REQUEST_ATTRIBUTE)
-					&& requestBodyMap.containsKey(Constants.ATTRIBUTE_NAME)) {
+			if (null !=requestBodyMap && (requestBodyMap.containsKey(Constants.SIGN_ENTITY) || requestBodyMap.containsKey(Constants.SIGN_VALUE))){
 				Object result = signatureService
-						.sign(gson.fromJson(requestBodyMap.get(Constants.ATTRIBUTE_NAME).toString(), mapType));
+						.sign(gson.fromJson(requestBodyMap.toString(), mapType));
 				response.setResult(result);
 				responseParams.setErrmsg("");
 				responseParams.setStatus(Response.Status.SUCCESSFUL);

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryUtilsController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryUtilsController.java
@@ -64,7 +64,7 @@ public class RegistryUtilsController {
 			Map<String, Object> requestBodyMap = apiMessage.getRequest().getRequestMap();
 			if (null !=requestBodyMap && (requestBodyMap.containsKey(Constants.SIGN_ENTITY) || requestBodyMap.containsKey(Constants.SIGN_VALUE))){
 				Object result = signatureService
-						.sign(gson.fromJson(requestBodyMap.toString(), mapType));
+						.sign(requestBodyMap);
 				response.setResult(result);
 				responseParams.setErrmsg("");
 				responseParams.setStatus(Response.Status.SUCCESSFUL);
@@ -92,11 +92,11 @@ public class RegistryUtilsController {
 		try {
 			watch.start("RegistryUtilsController.verifySignature");
 			Map<String, Object> map = apiMessage.getRequest().getRequestMap();
-			if (map.containsKey(Constants.REQUEST_ATTRIBUTE) && map.containsKey(Constants.ATTRIBUTE_NAME)) {
-				JsonObject obj = gson.fromJson(map.get(Constants.ATTRIBUTE_NAME).toString(), JsonObject.class);
-
+			String inputEntity = apiMessage.getRequest().getRequestMapAsString();
+			if (null != inputEntity && null != map && map.containsKey(Constants.SIGN_ENTITY)) {
+				JsonObject obj = gson.fromJson(inputEntity, JsonObject.class);
 				JsonArray arr = new JsonArray();
-				JsonElement entityElement = obj.get("entity");
+				JsonElement entityElement = obj.get(Constants.SIGN_ENTITY);
 				if (!entityElement.isJsonArray()) {
 					arr.add(entityElement);
 				} else {
@@ -155,7 +155,7 @@ public class RegistryUtilsController {
 	}
 
 	@RequestMapping(value = "/utils/keys/{id}", method = RequestMethod.GET)
-	public ResponseEntity<Response> getKey(@PathVariable String keyId) {
+	public ResponseEntity<Response> getKey( @PathVariable("id") String keyId) {
 		ResponseParams responseParams = new ResponseParams();
 		Response response = new Response(Response.API_ID.KEYS, "OK", responseParams);
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/SignatureServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/SignatureServiceImpl.java
@@ -88,7 +88,7 @@ public class SignatureServiceImpl implements SignatureService {
 		String result = null;
 		try {
 			response = restTemplate.getForEntity(keysURL + "/" + keyId, String.class);
-			result = new Gson().fromJson(response.getBody(), String.class);
+			result = response.getBody();
 		} catch (RestClientException ex) {
 			logger.error("RestClientException when verifying: ", ex);
 			throw new SignatureException().new UnreachableException(ex.getMessage());


### PR DESCRIPTION
Code change for sign api which is used for signing entity and value which is provided as input data
Example input:
{
  "id":"open-saber.utils.sign",
  "ver":"1.0",
  "ets":"11234",
  "params":{
    "did":"",
    "key":"",
    "msgid":""
  },
  "request":{
	"value":["sdfsfsfs","dsdss"]
   }
}