### PR TITLE
OS-160 Let the array node be separately created

### DIFF
--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -4,86 +4,56 @@ import org.apache.jena.vocabulary.RDF;
 
 public class Constants {
 
-	public static final String REQUEST_ATTRIBUTE_NAME = "dataObject";
-	public static final String RESPONSE_ATTRIBUTE = "responseModel";
-	public static final String ATTRIBUTE_NAME = "dataObject";
-	public static final String REQUEST_ATTRIBUTE = "requestModel";
-	public static final String REQUEST_OBJECT = "requestObject";
 	public static final String RDF_OBJECT = "rdfObject";
-	public static final String CONTROLLER_INPUT = "controllerInput";
 	public static final String SIGN_ENTITY = "entity";
 	public static final String SIGN_VALUE = "value";
-
-	public static final String LD_OBJECT = "ldObject";
-	public static final String METHOD_ORIGIN = "methodOrigin";
 	public static final String TOKEN_OBJECT = "x-authenticated-user-token";
-	public static final String SHEX_CREATE_PROPERTY_NAME = "validation.create.file";
-	public static final String SHEX_UPDATE_PROPERTY_NAME = "validation.update.file";
-	public static final String FIELD_CONFIG_SCEHEMA_FILE = "config.schema.file";
-	public static final String RDF_VALIDATION_MAPPER_OBJECT = "rdfValidationMapper";
-	public static final String SIGNED_PROPERTY = "signedProperties";
+	public static final String LD_JSON_MEDIA_TYPE = "application/ld+json";
 
-	public static final String DATABASE_PROVIDER = "database.provider";
-	public static final String NEO4J_DIRECTORY = "database.neo4j.database_directory";
-	public static final String ORIENTDB_DIRECTORY = "orientdb.directory";
-
-	public static final String TEST_ENVIRONMENT = "test";
-	public static final String NONE_STR = "none";
-	public static final String INTEGRATION_TEST_BASE_URL = "http://localhost:8080/";
-	public static final String TARGET_NODE_IRI = "http://www.w3.org/ns/shacl#targetNode";
-	public static final String CONTEXT_KEYWORD = "@context";
-
-	public static final String JENA_LD_FORMAT = "JSON-LD";
-
-	public static final String JSONLD_DATA_IS_MISSING = "JSON-LD data is missing!";
-	public static final String DUPLICATE_RECORD_MESSAGE = "Cannot insert duplicate record";
-	public static final String NO_ENTITY_AVAILABLE_MESSAGE = "No entity available";
-	public static final String ENTITY_NOT_FOUND = "Entity does not exist";
-	public static final String DELETE_UNSUPPORTED_OPERATION_ON_ENTITY = "Delete operation not supported";
-	public static final String READ_ON_DELETE_ENTITY_NOT_SUPPORTED = "Read on deleted entity not supported";
-	public static final String TOKEN_EXTRACTION_ERROR = "Unable to extract auth token";
-	public static final String JSONLD_PARSE_ERROR = "Unable to parse JSON-LD";
-	public static final String RDF_VALIDATION_MAPPING_ERROR = "Unable to map validations";
-	public static final String CUSTOM_EXCEPTION_ERROR = "Something went wrong!! Please try again later";
-	public static final String ADD_UPDATE_MULTIPLE_ENTITIES_MESSAGE = "Cannot add/update/view more than one entity";
-	public static final String AUDIT_IS_DISABLED = "Audit is disabled";
-	public static final String VALIDATION_CONFIGURATION_MISSING = "Configuration for validation file is missing";
-	public static final String SCHEMA_CONFIGURATION_MISSING = "Configuration for schema file is missing";
-	public static final String ENTITY_TYPE_NOT_PROVIDED = "Entity type is not provided in the input";
-	public static final String ENTITY_ID_MISMATCH = "Entity id is wrongly provided in the input";
-	public static final String SIGN_ERROR_MESSAGE = "Unable to get signature for data";
-	public static final String VERIFY_SIGN_ERROR_MESSAGE = "Unable to verify signature for data";
-	public static final String KEY_RETRIEVE_ERROR_MESSAGE = "Unable to retrieve key";
-	public static final String SCHEMA_TYPE_INVALID = "Invalid schema type";
-	public static final String INVALID_FRAME = "Domain must be defined in frame file"; 
-
-
+	public static final String PARENT_KEYWORD = "parent";
 	public static final String OPENSABER_REGISTRY_API_NAME = "opensaber-registry-api";
 	public static final String SUNBIRD_ENCRYPTION_SERVICE_NAME = "sunbird.encryption.service";
 	public static final String SUNBIRD_SIGNATURE_SERVICE_NAME = "sunbird.signature.service";
 	public static final String OPENSABER_DATABASE_NAME = "opensaber.database";
 	public static final String GRAPH_GLOBAL_CONFIG = "graph_global_config";
 	public static final String PERSISTENT_GRAPH = "persisten_graph";
+
+	// Internal properties
+	public static final String STATUS_KEYWORD = "_status";
 	public static final String STATUS_INACTIVE = "false";
 	public static final String STATUS_ACTIVE = "true";
-	public static final String STATUS_KEYWORD = "@status";
-	public static final String AUDIT_KEYWORD = "@audit";
-	public static final String CREATE_METHOD_ORIGIN = "add";
-	public static final String READ_METHOD_ORIGIN = "read";
-	public static final String UPDATE_METHOD_ORIGIN = "update";
-	public static final String SEARCH_METHOD_ORIGIN = "search";
-	public static final String FORWARD_SLASH = "/";
-	public static final String RDF_URL_SYNTAX_TYPE = RDF.uri + "type";
+	public static final String AUDIT_KEYWORD = "_audit";
+	public static final String ARRAY_NODE_KEYWORD = "_array_node";
+	public static final String ARRAY_ITEM = "_item";
+
+	// JSON LD specific
+	public static final String CONTEXT_KEYWORD = "@context";
 	public static final String TYPE_STR_JSON_LD = "@type";
 
+
+	// Configuration constants
+	public static final String FIELD_CONFIG_SCEHEMA_FILE = "config.schema.file";
+	public static final String DATABASE_PROVIDER = "database.provider";
+	public static final String NEO4J_DIRECTORY = "database.neo4j.database_directory";
+	public static final String ORIENTDB_DIRECTORY = "orientdb.directory";
+
+
+	public static final String TEST_ENVIRONMENT = "test";
+	public static final String INTEGRATION_TEST_BASE_URL = "http://localhost:8080/";
+
+	// Error messages.
+	public static final String CUSTOM_EXCEPTION_ERROR = "Something went wrong!! Please try again later";
+	public static final String SCHEMA_CONFIGURATION_MISSING = "Configuration for schema file is missing";
+	public static final String SIGN_ERROR_MESSAGE = "Unable to get signature for data";
+	public static final String VERIFY_SIGN_ERROR_MESSAGE = "Unable to verify signature for data";
+	public static final String KEY_RETRIEVE_ERROR_MESSAGE = "Unable to retrieve key";
+
 	// List of predicates introduced for digital signature.
-	public static final String SIGNATURES = "signatures";
-	public static final String SIGNATURE_OF = "signatureOf";
+	public static final String SIGNATURES_STR = "signatures";
 	public static final String SIGNATURE_FOR = "signatureFor";
 	public static final String SIGN_CREATOR = "creator";
 	public static final String SIGN_CREATED_TIMESTAMP = "created";
 	public static final String SIGN_NONCE = "nonce";
-	public static final String SIGN_TYPE = "type";
 	public static final String SIGN_SIGNATURE_VALUE = "signatureValue";
 
 	// List of request endpoints for post calls to validate request id
@@ -93,9 +63,6 @@ public class Constants {
 	public static final String REGISTRY_SEARCH_ENDPOINT = "/search";
 	public static final String SIGNATURE_SIGN_ENDPOINT = "/utils/sign";
 	public static final String SIGNATURE_VERIFY_ENDPOINT = "/utils/verify";
-
-	//Error Messages
-	public static final String NODE_TYPE_WRONG_MAPPED_ERROR_MSG = "Updation failed, entity type wrongly mapped with node";
 
 	public enum GraphDatabaseProvider {
 		NEO4J("NEO4J"), ORIENTDB("ORIENTDB"), SQLG("SQLG"), CASSANDRA("CASSANDRA"), TINKERGRAPH("TINKERGRAPH");

--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -10,7 +10,7 @@ public class Constants {
 	public static final String TOKEN_OBJECT = "x-authenticated-user-token";
 	public static final String LD_JSON_MEDIA_TYPE = "application/ld+json";
 
-	public static final String PARENT_KEYWORD = "parent";
+
 	public static final String OPENSABER_REGISTRY_API_NAME = "opensaber-registry-api";
 	public static final String SUNBIRD_ENCRYPTION_SERVICE_NAME = "sunbird.encryption.service";
 	public static final String SUNBIRD_SIGNATURE_SERVICE_NAME = "sunbird.signature.service";
@@ -25,6 +25,8 @@ public class Constants {
 	public static final String AUDIT_KEYWORD = "_audit";
 	public static final String ARRAY_NODE_KEYWORD = "_array_node";
 	public static final String ARRAY_ITEM = "_item";
+	public static final String INTERNAL_TYPE_KEYWORD = "_intType";
+	public static final String ROOT_KEYWORD = "_osroot";
 
 	// JSON LD specific
 	public static final String CONTEXT_KEYWORD = "@context";

--- a/java/registry/src/main/java/io/opensaber/registry/dao/IRegistryDao.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/IRegistryDao.java
@@ -11,11 +11,9 @@ public interface IRegistryDao {
 
 	void setPrivatePropertyList(List<String> privatePropertyList);
 	Vertex ensureParentVertex(Graph graph, String parentLabel);
-	String getParentName(JsonNode node);
-	String writeNodeEntity(Graph graph, JsonNode node);
 	List<String> getUUIDs(Graph graph, Set<String> labels);
 	String addEntity(JsonNode rootNode);
-	JsonNode getEntity(String uuid, ReadConfigurator readConfigurator);
+	JsonNode getEntity(String uuid, ReadConfigurator readConfigurator) throws Exception;
 	void updateVertex(Vertex rootVertex, JsonNode inputJsonNode);
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
@@ -59,88 +59,6 @@ public class RegistryDaoImpl implements IRegistryDao {
         this.privatePropertyList = privatePropertyList;
     }
 
-    private Vertex createVertex(Graph graph, String label) {
-        Vertex vertex = graph.addVertex(label);
-
-        vertex.property(TypePropertyHelper.getTypeName(), label);
-        try {
-            UUID uuid = UUID.fromString(vertex.id().toString());
-        } catch (IllegalArgumentException e) {
-            // Must be not a neo4j store. Create an explicit osid property.
-            // Note this will be OS unique record, but the database provider might choose to use only
-            // id field.
-            vertex.property(uuidPropertyName, shard.getDatabaseProvider().generateId(vertex));
-        }
-
-        return vertex;
-    }
-
-    /**
-     * Writes an array into the database. For each array item, if it is an object
-     * creates/populates a new vertex/table and stores the reference
-     *
-     * @param graph
-     * @param vertex
-     * @param entryKey
-     * @param arrayNode
-     */
-    private void writeArrayNode(Graph graph, Vertex vertex, String entryKey, ArrayNode arrayNode) {
-        List<String> uidList = new ArrayList<>();
-        boolean isArrayItemObject = arrayNode.get(0).isObject();
-
-        for(JsonNode jsonNode : arrayNode) {
-            if (jsonNode.isObject()) {
-                Vertex createdV = processNode(graph, entryKey, jsonNode);
-                uidList.add(createdV.id().toString());
-                addEdge(entryKey, vertex, createdV);
-            } else {
-                uidList.add(jsonNode.asText());
-            }
-        }
-
-        String label = entryKey;
-        if (isArrayItemObject) {
-            label = RefLabelHelper.getLabel(entryKey, uuidPropertyName);
-        }
-        vertex.property(label, StringUtils.arrayToCommaDelimitedString(uidList.toArray()));
-    }
-
-    private Vertex processNode(Graph graph, String label, JsonNode jsonObject) {
-        Vertex vertex = createVertex(graph, label);
-
-        jsonObject.fields().forEachRemaining(entry -> {
-            JsonNode entryValue = entry.getValue();
-            logger.debug("Processing {} -> {}", entry.getKey(), entry.getValue());
-
-            if (entryValue.isValueNode()) {
-                // Directly add under the vertex as a property
-                vertex.property(entry.getKey(), entryValue.asText());
-            } else if (entryValue.isObject()) {
-                // Recursive calls
-                Vertex v = processNode(graph, entry.getKey(), entryValue);
-                addEdge(entry.getKey(), vertex, v);
-                //String idToSet = databaseProviderWrapper.getDatabaseProvider().generateId(v);
-                vertex.property(RefLabelHelper.getLabel(entry.getKey(), uuidPropertyName), v.id().toString());
-                logger.debug("Added edge between {} and {}", vertex.label(), v.label());
-            } else if (entryValue.isArray()) {
-                writeArrayNode(graph, vertex, entry.getKey(), (ArrayNode) entry.getValue());
-            }
-        });
-        return vertex;
-    }
-
-    /**
-     * Adds an edge between two vertices
-     *
-     * @param label
-     * @param v1    the source
-     * @param v2    the target
-     * @return
-     */
-    private Edge addEdge(String label, Vertex v1, Vertex v2) {
-        return v1.addEdge(label, v2);
-    }
-
     /**
      * Ensures a parent vertex existence at the exit of this function
      *
@@ -155,7 +73,8 @@ public class RegistryDaoImpl implements IRegistryDao {
         GraphTraversalSource gtRootTraversal = graph.traversal().clone();
         Iterator<Vertex> iterVertex = gtRootTraversal.V().hasLabel(lblPredicate);
         if (!iterVertex.hasNext()) {
-            parentVertex = createVertex(graph, parentLabel);
+            VertexWriter vertexWriter = new VertexWriter(uuidPropertyName, shard, entityParenter);
+            parentVertex = vertexWriter.createVertex(graph, parentLabel);
             logger.info("Parent label {} created {}", parentLabel, parentVertex.id().toString());
         } else {
             parentVertex = iterVertex.next();
@@ -165,48 +84,6 @@ public class RegistryDaoImpl implements IRegistryDao {
         return parentVertex;
     }
 
-    /**
-     * Fetches the parent. In the current use cases, we expect only one
-     * top level parent is passed.
-     *
-     * @param node
-     * @return
-     */
-    public String getParentName(JsonNode node) {
-        return node.fieldNames().next();
-    }
-
-    /**
-     * Writes the node entity into the database.
-     *
-     * @param graph
-     * @param node
-     * @return
-     */
-    public String writeNodeEntity(Graph graph, JsonNode node) {
-        String parentName = getParentName(node);
-        String parentGroupName = ParentLabelGenerator.getLabel(parentName);
-        Vertex parentVertex = entityParenter.getKnownParentVertex(parentName, "shard1");
-
-        Vertex resultVertex = null;
-        Iterator<Map.Entry<String, JsonNode>> entryIterator = node.fields();
-        while (entryIterator.hasNext()) {
-            Map.Entry<String, JsonNode> entry = entryIterator.next();
-
-            // It is expected that node is wrapped under a root, which is the parent name/definition
-            if (entry.getValue().isObject()) {
-                resultVertex = processNode(graph, entry.getKey(), entry.getValue());
-                // The parentVertex and the entity are connected. The parentVertex doesn't have
-                // identifiers set on itself, whereas the entity just created has reference to parent.
-                //String idToSet = databaseProviderWrapper.getDatabaseProvider().generateId(parentVertex);
-                resultVertex.property(RefLabelHelper.getLabel(parentGroupName, uuidPropertyName), parentVertex.id().toString());
-
-                addEdge(entry.getKey(), resultVertex, parentVertex);
-            }
-        }
-
-        return resultVertex.id().toString();
-    }
 
     /**
      * Retrieves all vertex UUID for given all labels.
@@ -235,7 +112,8 @@ public class RegistryDaoImpl implements IRegistryDao {
         try (OSGraph osGraph = databaseProvider.getOSGraph()) {
             Graph graph = osGraph.getGraphStore();
             try (Transaction tx = databaseProvider.startTransaction(graph)) {
-                entityId = writeNodeEntity(graph, rootNode);
+                VertexWriter vertexWriter = new VertexWriter(uuidPropertyName, shard, entityParenter);
+                entityId = vertexWriter.writeNodeEntity(graph, rootNode);
                 databaseProvider.commitTransaction(graph, tx);
             }
         } catch (Exception e) {
@@ -250,7 +128,7 @@ public class RegistryDaoImpl implements IRegistryDao {
      * @param readConfigurator
      * @return
      */
-    public JsonNode getEntity(String uuid, ReadConfigurator readConfigurator) {
+    public JsonNode getEntity(String uuid, ReadConfigurator readConfigurator) throws Exception {
         if (null == privatePropertyList) {
             privatePropertyList = new ArrayList<>();
             setPrivatePropertyList(schemaConfigurator.getAllPrivateProperties());
@@ -265,8 +143,6 @@ public class RegistryDaoImpl implements IRegistryDao {
                 result = vr.read(uuid);
                 databaseProvider.commitTransaction(graph, tx);
             }
-        } catch (Exception e) {
-            logger.error("Exception occurred during read entity ", e);
         }
         return result;
     }
@@ -322,8 +198,11 @@ public class RegistryDaoImpl implements IRegistryDao {
             if(!isArrayElement){
                 deleteVertices(graph, rootVertex, parentNodeLabel, null);
             }
+
+            VertexWriter vertexWriter = new VertexWriter(uuidPropertyName, shard, entityParenter);
+
             //Add new vertex
-            Vertex newChildVertex = createVertex(graph, parentNodeLabel);
+            Vertex newChildVertex = vertexWriter.createVertex(graph, parentNodeLabel);
             updateProperties(elementNode,newChildVertex);
             String nodeOsidLabel = RefLabelHelper.getLabel(parentNodeLabel, uuidPropertyName);
             VertexProperty<Object> vertexProperty =  rootVertex.property(nodeOsidLabel);
@@ -333,7 +212,7 @@ public class RegistryDaoImpl implements IRegistryDao {
             } else {
                 rootVertex.property(nodeOsidLabel, newChildVertex.id().toString());
             }
-            addEdge(parentNodeLabel, rootVertex, newChildVertex);
+            vertexWriter.addEdge(parentNodeLabel, rootVertex, newChildVertex);
             return newChildVertex.id().toString();
         } else {
             Vertex updateVertex = graph.vertices(elementNode.get(uuidPropertyName).asText()).next();

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
@@ -9,7 +9,6 @@ import io.opensaber.registry.middleware.util.JSONUtil;
 import io.opensaber.registry.util.ReadConfigurator;
 import io.opensaber.registry.util.RefLabelHelper;
 import io.opensaber.registry.util.TypePropertyHelper;
-import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -17,10 +16,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 /**
  * Given a vertex from the graph, constructs a json out it
@@ -45,6 +41,7 @@ public class VertexReader {
     /**
      * For the given vertex, constructs the json ObjectNode.
      * If the given vertex, contains an array, a mere reference is put up without any expansion.
+     *
      * @param currVertex
      * @return
      */
@@ -79,7 +76,7 @@ public class VertexReader {
                     boolean canAdd = true;
                     if (privatePropertyList.contains(prop.key())) {
                         canAdd &= configurator.isIncludeEncryptedProp();
-                    } else if (prop.key().equals(Constants.PARENT_KEYWORD)) {
+                    } else if (prop.key().equals(Constants.ROOT_KEYWORD)) {
                         canAdd = false;
                     }
 
@@ -100,6 +97,7 @@ public class VertexReader {
 
     /**
      * Loads the signature vertices
+     *
      * @param currVertex
      * @return
      */
@@ -129,6 +127,7 @@ public class VertexReader {
 
     /**
      * Determines whether the depth setting allows to fetch this additional vertices
+     *
      * @param currLevel
      * @param maxLevel
      * @return
@@ -139,21 +138,39 @@ public class VertexReader {
 
     /**
      * Loads the OUT edge vertices of the given vertex
+     *
      * @param vertex
      * @param currLevel
      */
     private void loadOtherVertices(Vertex vertex, int currLevel) {
+        // NOTE: We can load selective vertices, but we don't know the labels here.
+        // So in the process, we will have loaded signature nodes as well here
         Iterator<Vertex> otherVertices = vertex.vertices(Direction.OUT);
+
         int tempCurrLevel = currLevel;
         while (otherVertices.hasNext()) {
             Vertex currVertex = otherVertices.next();
-            if (!currVertex.label().equals(entityType)) {
+            VertexProperty internalTypeProp = currVertex.property(Constants.INTERNAL_TYPE_KEYWORD);
+            String internalType = internalTypeProp.isPresent() ? internalTypeProp.value().toString() : "";
+
+            // Do not work on the signatures again here.
+            if (!currVertex.label().equals(entityType) &&
+                            !internalType.equals(Constants.SIGNATURES_STR)) {
+                logger.debug("Reading vertex label {} and internal type {}", currVertex.label(), internalType);
+
                 ObjectNode node = constructObject(currVertex);
                 uuidNodeMap.put(node.get(uuidPropertyName).textValue(), node);
 
+                // Load any signatures within child entity
                 ArrayNode signatureNode = loadSignatures(currVertex);
                 if (signatureNode != null) {
                     node.set(Constants.SIGNATURES_STR, signatureNode);
+                }
+
+                if (currVertex.property(Constants.TYPE_STR_JSON_LD).value().equals(Constants.ARRAY_NODE_KEYWORD)) {
+                    // Not incrementing levels here, because it is we who inserted a blank array_node
+                    // for data modelling.
+                    loadOtherVertices(currVertex, tempCurrLevel);
                 }
 
                 if (canLoadVertex(++tempCurrLevel, configurator.getDepth())) {
@@ -164,53 +181,78 @@ public class VertexReader {
         }
     }
 
+    private void printUuidNodeMap() {
+        uuidNodeMap.keySet().forEach(entry -> {
+            logger.debug(entry.toString() + " -> " + uuidNodeMap.get(entry).get(Constants.TYPE_STR_JSON_LD));
+        });
+    }
+
     /**
      * After loading all the associated objects, this function sets the object content in
      * the right paths
+     *
      * @param entityNode
      */
-    private void expandChildObject(ObjectNode entityNode) {
-        entityNode.fields().forEachRemaining(entry -> {
-            if (entry.getValue().toString().compareToIgnoreCase(entityType) == 0) {
-                // Same as parent, don't expand
-                // do nothing
-                return;
-            } else if (entry.getKey().compareToIgnoreCase(uuidPropertyName) == 0){
+    private ArrayNode expandChildObject(ObjectNode entityNode) {
+        ArrayNode resultArr = JsonNodeFactory.instance.arrayNode();
+
+        List<String> fieldNames = new ArrayList<String>();
+        entityNode.fieldNames().forEachRemaining(fieldName -> {
+            fieldNames.add(fieldName);
+        });
+
+        for (String field : fieldNames) {
+            JsonNode entry = entityNode.get(field);
+
+            logger.debug("Working on field {}", field );
+
+            if (field.equals(uuidPropertyName)) {
                 // has a uuid that may have been populated
                 // This could be a textual value or an array
-                if (uuidNodeMap.containsKey(entry.getValue().textValue())) {
-                    entityNode.setAll(uuidNodeMap.get(entry.getValue().textValue()));
+                JsonNode entryValNode = entry;
+                String uuidVal = entryValNode.asText();
+                JsonNode temp = uuidNodeMap.getOrDefault(uuidVal, null);
+                boolean isArray = (temp != null && temp.get(Constants.TYPE_STR_JSON_LD).asText().equals(Constants.ARRAY_NODE_KEYWORD));
+
+                if (temp == null) {
+                    // No node loaded for this.
+                    // No action required.
+                } else if (!isArray) {
+                    logger.debug("Field {} Not an array type", field);
+                    entityNode.setAll(uuidNodeMap.get(uuidVal));
                 } else {
-                    logger.debug("Key {} not found", entry.getValue());
-                }
-            } else if (entry.getValue().isObject()) {
-                logger.debug("Key {} is an object. Expanding further.", entry.getKey());
-                expandChildObject((ObjectNode) entry.getValue());
-            } else if (entry.getValue().isArray()) {
-                logger.debug("Key {} is an array.", entry.getKey());
-                ArrayNode ar = (ArrayNode) entry.getValue();
-                ArrayNode expanded = JsonNodeFactory.instance.arrayNode();
-                for (JsonNode node : ar) {
-                    if (!node.get(uuidPropertyName).isNull() &&
-                            uuidNodeMap.containsKey(node.get(uuidPropertyName).textValue())) {
-                            ObjectNode ovalue = uuidNodeMap.get(node.get(uuidPropertyName).textValue());
-                            expanded.add(ovalue);
-                    } else {
-                        logger.info("Not found in map, maybe too deep");
+                    // Now first query the uuidNodeMap for the list of items
+                    JsonNode blankNode = temp;
+
+                    Iterator<Map.Entry<String, JsonNode>> entryIterator = blankNode.fields();
+                    while (entryIterator.hasNext()) {
+                        Map.Entry<String, JsonNode> item = entryIterator.next();
+                        JsonNode ar = item.getValue();
+                        for (JsonNode node : ar) {
+                            ObjectNode ovalue = uuidNodeMap.getOrDefault(node.get(uuidPropertyName).asText(), null);
+                            if (ovalue != null) {
+                                resultArr.add(ovalue);
+                            } else {
+                                logger.info("Field {} Array items not found in map", field);
+                            }
+                        }
                     }
                 }
-
-                if (expanded.size() != 0) {
-                    entry.setValue(expanded);
+            } else if (entry.isObject()) {
+                logger.debug("Field {} is an object. Expanding further.", entry);
+                ArrayNode expandChildObject = expandChildObject((ObjectNode) entry);
+                if (expandChildObject != null && expandChildObject.size() > 0) {
+                    entityNode.set(field, expandChildObject);
                 }
             }
-        });
+        }
+        return resultArr;
     }
 
     /**
      * Hits the database to read contents
      *
-     * @param osid         the id to be read
+     * @param osid the id to be read
      * @return
      * @throws Exception
      */
@@ -231,23 +273,29 @@ public class VertexReader {
         ArrayNode signatureNode = loadSignatures(rootVertex);
         if (signatureNode != null) {
             rootNode.set(Constants.SIGNATURES_STR, signatureNode);
+        } else {
+            rootNode.remove(Constants.SIGNATURES_STR);
         }
 
         if (configurator.getDepth() > 0) {
             loadOtherVertices(rootVertex, currLevel);
         }
 
-        // After reading the type, now trim the @type property
-        if (configurator.isIncludeTypeAttributes()) {
-            JSONUtil.removeNode(rootNode, Constants.TYPE_STR_JSON_LD);
-        }
+        printUuidNodeMap();
+
+        logger.info("Finished loading information. Start creating the response");
 
         ObjectNode entityNode = JsonNodeFactory.instance.objectNode();
-        entityNode.set(entityType, rootNode);
-
         // For the entity Node, now go and replace the array values with actual objects.
         // The properties could exist anywhere. Refer to the local arrMap.
-        expandChildObject(entityNode);
+        expandChildObject(rootNode);
+
+        entityNode.set(entityType, rootNode);
+
+        // After reading the entire type, now trim the @type property
+        if (!configurator.isIncludeTypeAttributes()) {
+            JSONUtil.removeNode(entityNode, Constants.TYPE_STR_JSON_LD);
+        }
 
         return entityNode;
     }

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
@@ -1,0 +1,183 @@
+package io.opensaber.registry.dao;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.sink.shard.Shard;
+import io.opensaber.registry.util.EntityParenter;
+import io.opensaber.registry.util.ParentLabelGenerator;
+import io.opensaber.registry.util.RefLabelHelper;
+import io.opensaber.registry.util.TypePropertyHelper;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+public class VertexWriter {
+    private String uuidPropertyName;
+    private Shard shard;
+    private EntityParenter entityParenter;
+    private String parentOSid;
+
+    private Logger logger = LoggerFactory.getLogger(VertexWriter.class);
+
+    public VertexWriter(String uuidPropertyName, Shard shard, EntityParenter entityParent) {
+        this.uuidPropertyName = uuidPropertyName;
+        this.shard = shard;
+        this.entityParenter = entityParent;
+    }
+
+
+    public Vertex createVertex(Graph graph, String label) {
+        Vertex vertex = graph.addVertex(label);
+
+        vertex.property(TypePropertyHelper.getTypeName(), label);
+        try {
+            UUID uuid = UUID.fromString(vertex.id().toString());
+        } catch (IllegalArgumentException e) {
+            // Must be not a neo4j store. Create an explicit osid property.
+            // Note this will be OS unique record, but the database provider might choose to use only
+            // id field.
+            vertex.property(uuidPropertyName, shard.getDatabaseProvider().generateId(vertex));
+        }
+
+        return vertex;
+    }
+
+    /**
+     * Writes an array into the database. For each array item, if it is an object
+     * creates/populates a new vertex/table and stores the reference
+     *
+     * @param graph
+     * @param vertex
+     * @param entryKey
+     * @param arrayNode
+     */
+    private void writeArrayNode(Graph graph, Vertex vertex, String entryKey, ArrayNode arrayNode) {
+        List<String> uidList = new ArrayList<>();
+        boolean isArrayItemObject = arrayNode.get(0).isObject();
+        boolean isSignature = entryKey.equals(Constants.SIGNATURES_STR);
+
+        Vertex blankNode = vertex;
+        String label = entryKey;
+        if (isArrayItemObject) {
+            label = RefLabelHelper.getLabel(entryKey, uuidPropertyName);
+            blankNode = createVertex(graph, Constants.ARRAY_NODE_KEYWORD);
+
+            addEdge(entryKey, vertex, blankNode);
+            vertex.property(label, blankNode.id());
+            blankNode.property(Constants.PARENT_KEYWORD, parentOSid);
+        }
+
+        for(JsonNode jsonNode : arrayNode) {
+            if (jsonNode.isObject()) {
+                Vertex createdV = processNode(graph, entryKey, jsonNode);
+                createdV.property(Constants.PARENT_KEYWORD, parentOSid);
+                uidList.add(createdV.id().toString());
+                if (isSignature) {
+                    addEdge(jsonNode.get(Constants.SIGNATURE_FOR).textValue(), blankNode, createdV);
+                } else {
+                    addEdge(entryKey + Constants.ARRAY_ITEM, blankNode, createdV);
+                }
+            } else {
+                uidList.add(jsonNode.asText());
+            }
+        }
+
+        // Set up references on a blank node.
+        blankNode.property(label, StringUtils.arrayToCommaDelimitedString(uidList.toArray()));
+    }
+
+    private Vertex processNode(Graph graph, String label, JsonNode jsonObject) {
+        Vertex vertex = createVertex(graph, label);
+        if (parentOSid == null || parentOSid.isEmpty()) {
+            parentOSid = vertex.id().toString();
+        }
+
+        jsonObject.fields().forEachRemaining(entry -> {
+            JsonNode entryValue = entry.getValue();
+            logger.debug("Processing {} -> {}", entry.getKey(), entry.getValue());
+
+            if (entryValue.isValueNode()) {
+                // Directly add under the vertex as a property
+                vertex.property(entry.getKey(), entryValue.asText());
+            } else if (entryValue.isObject()) {
+                // Recursive calls
+                Vertex v = processNode(graph, entry.getKey(), entryValue);
+                addEdge(entry.getKey(), vertex, v);
+                //String idToSet = databaseProviderWrapper.getDatabaseProvider().generateId(v);
+                vertex.property(RefLabelHelper.getLabel(entry.getKey(), uuidPropertyName), v.id().toString());
+                v.property(Constants.PARENT_KEYWORD, parentOSid);
+
+                logger.debug("Added edge between {} and {}", vertex.label(), v.label());
+            } else if (entryValue.isArray()) {
+                writeArrayNode(graph, vertex, entry.getKey(), (ArrayNode) entry.getValue());
+            }
+        });
+        return vertex;
+    }
+
+    /**
+     * Adds an edge between two vertices
+     *
+     * @param label
+     * @param v1    the source
+     * @param v2    the target
+     * @return
+     */
+    public Edge addEdge(String label, Vertex v1, Vertex v2) {
+        return v1.addEdge(label, v2);
+    }
+
+    /**
+     * Fetches the parent. In the current use cases, we expect only one
+     * top level parent is passed.
+     *
+     * @param node
+     * @return
+     */
+    private String getParentName(JsonNode node) {
+        return node.fieldNames().next();
+    }
+
+
+    private void setParentId(String id) {
+        this.parentOSid = id;
+    }
+
+    /**
+     * Writes the node entity into the database.
+     *
+     * @param graph
+     * @param node
+     * @return
+     */
+    public String writeNodeEntity(Graph graph, JsonNode node) {
+        String parentName = getParentName(node);
+        String parentGroupName = ParentLabelGenerator.getLabel(parentName);
+        Vertex parentVertex = entityParenter.getKnownParentVertex(parentName, shard.getShardId());
+
+        Vertex resultVertex = null;
+        Iterator<Map.Entry<String, JsonNode>> entryIterator = node.fields();
+        while (entryIterator.hasNext()) {
+            Map.Entry<String, JsonNode> entry = entryIterator.next();
+
+            // It is expected that node is wrapped under a root, which is the parent name/definition
+            if (entry.getValue().isObject()) {
+                resultVertex = processNode(graph, entry.getKey(), entry.getValue());
+                // The parentVertex and the entity are connected. The parentVertex doesn't have
+                // identifiers set on itself, whereas the entity just created has reference to parent.
+                //String idToSet = databaseProviderWrapper.getDatabaseProvider().generateId(parentVertex);
+                resultVertex.property(RefLabelHelper.getLabel(parentGroupName, uuidPropertyName), parentVertex.id().toString());
+
+                addEdge(entry.getKey(), resultVertex, parentVertex);
+            }
+        }
+
+        return resultVertex.id().toString();
+    }
+}

--- a/java/registry/src/main/java/io/opensaber/registry/service/RegistryService.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/RegistryService.java
@@ -14,8 +14,8 @@ public interface RegistryService {
 
 	 String addEntity(String jsonString) throws Exception;
 
-     JsonNode getEntity(String id, ReadConfigurator configurator);
+     JsonNode getEntity(String id, ReadConfigurator configurator) throws Exception;
 
-	 public void updateEntity(String jsonString) throws Exception;
+     void updateEntity(String jsonString) throws Exception;
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/service/SignatureHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/SignatureHelper.java
@@ -35,7 +35,7 @@ public class SignatureHelper {
         Map signReq = new HashMap<String, Object>();
         signReq.put("entity", rootNode);
         Map<String, Object> signMap = (Map<String, Object>) signatureService.sign(signReq);
-        mergeSign(rootNode.get(registryRootEntityType).get(Constants.SIGNATURES), signMap);
+        mergeSign(rootNode.get(registryRootEntityType).get(Constants.SIGNATURES_STR), signMap);
         return signedRoot;
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -160,7 +160,7 @@ public class RegistryServiceImpl implements RegistryService {
         return entityId;
     }
 
-    public JsonNode getEntity(String id, ReadConfigurator configurator) {
+    public JsonNode getEntity(String id, ReadConfigurator configurator) throws Exception {
         JsonNode result = tpGraphMain.getEntity(id, configurator);
         return result;
     }
@@ -206,11 +206,11 @@ public class RegistryServiceImpl implements RegistryService {
                     //sign the entitynode
                     if (signatureEnabled) {
                         signatureHelper.signJson(entityNode);
-                        JsonNode signNode = entityNode.get(registryRootEntityType).get(Constants.SIGNATURES);
+                        JsonNode signNode = entityNode.get(registryRootEntityType).get(Constants.SIGNATURES_STR);
                         if (signNode.isArray()) {
                             signNode = getEntitySignNode(signNode);
                         }
-                        Iterator<Vertex> vertices = rootVertex.vertices(Direction.OUT,Constants.SIGNATURES);
+                        Iterator<Vertex> vertices = rootVertex.vertices(Direction.OUT,Constants.SIGNATURES_STR);
                         while (null != vertices && vertices.hasNext()) {
                             Vertex signVertex = vertices.next();
                             if (signVertex.property(Constants.SIGNATURE_FOR).value().equals(registryRootEntityType)) {
@@ -231,11 +231,11 @@ public class RegistryServiceImpl implements RegistryService {
                     //sign the entitynode
                     if (signatureEnabled) {
                         signatureHelper.signJson(entityNode);
-                        JsonNode signNode = entityNode.get(registryRootEntityType).get(Constants.SIGNATURES);
+                        JsonNode signNode = entityNode.get(registryRootEntityType).get(Constants.SIGNATURES_STR);
                         if (signNode.isArray()) {
                             signNode = getEntitySignNode(signNode);
                         }
-                        Iterator<Vertex> vertices = rootVertex.vertices(Direction.OUT,Constants.SIGNATURES);
+                        Iterator<Vertex> vertices = rootVertex.vertices(Direction.OUT,Constants.SIGNATURES_STR);
                         while (null != vertices && vertices.hasNext()) {
                             Vertex signVertex = vertices.next();
                             if (signVertex.property(Constants.SIGNATURE_FOR).value().equals(registryRootEntityType)) {

--- a/java/registry/src/main/java/io/opensaber/registry/util/RefLabelHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/RefLabelHelper.java
@@ -5,6 +5,7 @@ package io.opensaber.registry.util;
  */
 public class RefLabelHelper {
     private static String SEPARATOR = "_";
+    private static String ARRAY_SEPARATOR = "_arr_";
 
     /**
      * Generates the key that could be persisted for a given reference
@@ -15,6 +16,28 @@ public class RefLabelHelper {
      */
     public static String getLabel(String referenceName, String id) {
         return referenceName + SEPARATOR + id;
+    }
+
+    /**
+     * Generates the key that could be persisted for a given reference
+     * and id
+     * @param referenceName - the other reference
+     * @param id - the id to suffix
+     * @return
+     */
+    public static String getArrayLabel(String referenceName, String id) {
+        return referenceName + ARRAY_SEPARATOR + id;
+    }
+
+    /**
+     * Given a label and id, identifies if the label was
+     * generated using this class.
+     * @param lbl
+     * @param id
+     * @return
+     */
+    public static boolean isArrayLabel(String lbl, String id) {
+        return lbl.contains(ARRAY_SEPARATOR) && lbl.contains(id);
     }
 
     /**

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -108,7 +108,7 @@
         <appender-ref ref="RegistryAuditAppender"/>
     </logger>
 
-    <root level="INFO" additivity="FALSE">
+    <root level="DEBUG" additivity="FALSE">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>
     </root>


### PR DESCRIPTION
The array node is tagged as `@type: _array_node` and has out edges labeled as `<referencedEntityName>_item` to the actual data. When the data is read back, the _array_node presence to the caller is not let known. It is OpenSABER that does this for internal data model and so the clients needn't know it.
Also, a new property _osroot has been tagged in every child/sub entity that points the top most root. This is expected to be useful for update, search APIs.