### PR TITLE
OS-163 Fix postgres custom id support

### DIFF
--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -214,7 +214,7 @@
 		<dependency>
 			<groupId>org.umlg</groupId>
 			<artifactId>sqlg-postgres</artifactId>
-			<version>1.5.2</version>
+			<version>2.0.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
@@ -75,7 +75,7 @@ public class RegistryDaoImpl implements IRegistryDao {
      */
     public JsonNode getEntity(Graph graph, String uuid, ReadConfigurator readConfigurator) throws Exception {
 
-        VertexReader vr = new VertexReader(graph, readConfigurator, uuidPropertyName, definitionsManager);
+        VertexReader vr = new VertexReader(shard.getDatabaseProvider(), graph, readConfigurator, uuidPropertyName, definitionsManager);
         JsonNode result = vr.read(uuid);
 
         if (!shard.getShardLabel().isEmpty()) {
@@ -90,7 +90,7 @@ public class RegistryDaoImpl implements IRegistryDao {
 
     public JsonNode getEntity(Graph graph, Vertex vertex, ReadConfigurator readConfigurator) {
 
-        VertexReader vr = new VertexReader(graph, readConfigurator, uuidPropertyName, definitionsManager);
+        VertexReader vr = new VertexReader(shard.getDatabaseProvider(), graph, readConfigurator, uuidPropertyName, definitionsManager);
         JsonNode result = vr.constructObject(vertex);
 
         if (!shard.getShardLabel().isEmpty()) {

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
@@ -135,8 +135,8 @@ public class VertexReader {
             }
         }
 
-        // Here we set the id
-        //contentNode.put(uuidPropertyName, currVertex.id().toString());
+        // Here we set the id - in neo4j this is must.
+        contentNode.put(uuidPropertyName, databaseProvider.getId(currVertex));
 
         return contentNode;
     }

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opensaber.registry.exception.RecordNotFoundException;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.middleware.util.JSONUtil;
+import io.opensaber.registry.sink.DatabaseProvider;
 import io.opensaber.registry.util.Definition;
 import io.opensaber.registry.util.DefinitionsManager;
 import io.opensaber.registry.util.ReadConfigurator;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * Given a vertex from the graph, constructs a json out it
  */
 public class VertexReader {
+    private DatabaseProvider databaseProvider;
     private Graph graph;
     private ReadConfigurator configurator;
     private String uuidPropertyName;
@@ -40,8 +42,9 @@ public class VertexReader {
 
     private Logger logger = LoggerFactory.getLogger(VertexReader.class);
 
-    public VertexReader(Graph graph, ReadConfigurator configurator, String uuidPropertyName,
+    public VertexReader(DatabaseProvider databaseProvider, Graph graph, ReadConfigurator configurator, String uuidPropertyName,
             DefinitionsManager definitionsManager) {
+        this.databaseProvider = databaseProvider;
         this.graph = graph;
         this.configurator = configurator;
         this.uuidPropertyName = uuidPropertyName;
@@ -133,7 +136,7 @@ public class VertexReader {
         }
 
         // Here we set the id
-        contentNode.put(uuidPropertyName, currVertex.id().toString());
+        //contentNode.put(uuidPropertyName, currVertex.id().toString());
 
         return contentNode;
     }
@@ -298,6 +301,35 @@ public class VertexReader {
     }
 
     /**
+     * Neo4j supports custom ids and so we can directly query vertex with id - without client side filtering.
+     * SqlG does not support custom id, but the result is direct from the database without client side filtering
+     *      unlike Neo4j.
+     * @param osid the osid of vertex to be loaded
+     * @return the vertex associated with osid passed
+     */
+    private Vertex getRootVertex(String osid) {
+        Vertex rootVertex = null;
+        Iterator<Vertex> itrV = null;
+        switch (databaseProvider.getProvider()) {
+            case NEO4J:
+                itrV = graph.vertices(osid);
+                break;
+            case SQLG:
+                itrV = graph.traversal().clone().V().has(uuidPropertyName, osid);
+                break;
+            default:
+                itrV = graph.vertices(osid);
+                break;
+        }
+
+        if (itrV.hasNext()) {
+            rootVertex = itrV.next();
+        }
+
+        return rootVertex;
+    }
+
+    /**
      * Hits the database to read contents
      *
      * @param osid
@@ -306,11 +338,10 @@ public class VertexReader {
      * @throws Exception
      */
     public JsonNode read(String osid) throws Exception {
-        Iterator<Vertex> itrV = graph.vertices(osid);
-        if (!itrV.hasNext()) {
+        Vertex rootVertex = getRootVertex(osid);
+        if (null == rootVertex) {
             throw new Exception("Invalid id");
         }
-        Vertex rootVertex = itrV.next();
 
         int currLevel = 0;
         if (rootVertex.property(Constants.STATUS_KEYWORD).isPresent()

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -209,19 +209,16 @@ public class RegistryServiceImpl implements RegistryService {
         if (encryptionEnabled) {
             rootNode = encryptionHelper.getEncryptedJson(rootNode);
         }
+
         JsonNode childElementNode = rootNode.elements().next();
         DatabaseProvider databaseProvider = shard.getDatabaseProvider();
         ReadConfigurator readConfigurator = new ReadConfigurator();
-        if (signatureEnabled) {
-            readConfigurator.setIncludeSignatures(true);
-        } else {
-            readConfigurator.setIncludeSignatures(false);
-        }
+        readConfigurator.setIncludeSignatures(signatureEnabled);
 
         try (OSGraph osGraph = databaseProvider.getOSGraph()) {
             Graph graph = osGraph.getGraphStore();
             Transaction tx = databaseProvider.startTransaction(graph);
-            VertexReader vr = new VertexReader(graph, readConfigurator, uuidPropertyName, definitionsManager);
+            VertexReader vr = new VertexReader(databaseProvider, graph, readConfigurator, uuidPropertyName, definitionsManager);
             String entityNodeType;
 
             if (null != tx) {

--- a/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 public abstract class DatabaseProvider {
+    private Constants.GraphDatabaseProvider provider;
     private String uuidPropertyName;
     private Optional<Boolean> supportsTransaction = Optional.empty();
 
@@ -146,7 +147,15 @@ public abstract class DatabaseProvider {
         return uuidPropertyName;
     }
 
-    public void setUuidPropertyName(String uuidPropertyName) {
+    protected void setUuidPropertyName(String uuidPropertyName) {
         this.uuidPropertyName = uuidPropertyName;
+    }
+
+    public Constants.GraphDatabaseProvider getProvider() {
+        return this.provider;
+    }
+
+    protected void setProvider(Constants.GraphDatabaseProvider provider) {
+        this.provider = provider;
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -4,6 +4,7 @@ import com.steelbridgelabs.oss.neo4j.structure.Neo4JEdge;
 import com.steelbridgelabs.oss.neo4j.structure.Neo4JElementIdProvider;
 import com.steelbridgelabs.oss.neo4j.structure.Neo4JGraph;
 import com.steelbridgelabs.oss.neo4j.structure.Neo4JVertex;
+import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.model.DBConnectionInfo;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -29,6 +30,7 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 	public Neo4jGraphProvider(DBConnectionInfo connection, String uuidPropName) {
 		connectionInfo = connection;
 		profilerEnabled = connection.isProfilerEnabled();
+		setProvider(Constants.GraphDatabaseProvider.NEO4J);
 		setUuidPropertyName(uuidPropName);
 
 		// TODO: Check with auth

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -1,5 +1,6 @@
 package io.opensaber.registry.sink;
 
+import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.model.DBConnectionInfo;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
@@ -22,6 +23,7 @@ public class SqlgProvider extends DatabaseProvider {
 		config.setProperty("jdbc.url", connectionInfo.getUri());
 		config.setProperty("jdbc.username", connectionInfo.getUsername());
 		config.setProperty("jdbc.password", connectionInfo.getPassword());
+		setProvider(Constants.GraphDatabaseProvider.SQLG);
 		setUuidPropertyName(uuidPropertyName);
 		graph = SqlgGraph.open(config);
 		customGraph = new OSGraph(graph, false);


### PR DESCRIPTION
The record id with Postgres was of the form 
> 1-public::Teacher:2 
where 1 represented the OpenSABER shard label and public::Teacher:2 was thrown back as id from SQLG. This id must be a UUID that OS generates.

The generateId and getId are existing methods in the DatabaseProvider that are over-rided by corresponding implementations. They are now put to use for osid value generation instead of using vertex.id().

The databaseProvider is now added as a param to VertexReader for us to figure out the logic for vertex filtering.

Upgraded SQLG-postgres to 2.0.0 while checking the issue we raised on sqlg - issue [324](https://github.com/pietermartin/sqlg/issues/324). This upgrade didn't help though.

** Testing **
Both Neo4j and Postgres was verified for uuid - return upon add and for reads. 
Even though it appears that V().has(property, value) appears that it will load all the vertices, unlike neo4j library, sqlg library does a straight query and retrieves directly the record. Query below:
`SELECT
	"public"."V_Vehicle"."ID" AS "alias1",
	"public"."V_Vehicle"."kerbWeight" AS "alias2",
	"public"."V_Vehicle"."registrationNumber" AS "alias3",
	"public"."V_Vehicle"."@type" AS "alias4",
	"public"."V_Vehicle"."model" AS "alias5",
	"public"."V_Vehicle"."osid" AS "alias6",
	"public"."V_Vehicle"."yearManufactured" AS "alias7",
	"public"."V_Vehicle"."manufacturer" AS "alias8"
FROM
	"public"."V_Vehicle"
WHERE
	( "public"."V_Vehicle"."osid" = '253ecd75-9445-4fc9-8cef-e2116712eada')]`