### PR TITLE
Os 174: Input Validation and definitions manager

### DIFF
--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -65,6 +65,10 @@ public class Constants {
 	public static final String REGISTRY_SEARCH_ENDPOINT = "/search";
 	public static final String SIGNATURE_SIGN_ENDPOINT = "/utils/sign";
 	public static final String SIGNATURE_VERIFY_ENDPOINT = "/utils/verify";
+	
+	//class path for json resources from _schemas folder
+	public static final String RESOURCE_LOCATION= "classpath*:public/_schemas/*.json";
+
 
 	public enum GraphDatabaseProvider {
 		NEO4J("NEO4J"), ORIENTDB("ORIENTDB"), SQLG("SQLG"), CASSANDRA("CASSANDRA"), TINKERGRAPH("TINKERGRAPH");

--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -67,7 +67,7 @@ public class Constants {
 	public static final String SIGNATURE_VERIFY_ENDPOINT = "/utils/verify";
 	
 	//class path for json resources from _schemas folder
-	public static final String RESOURCE_LOCATION= "classpath*:public/_schemas/*.json";
+	public static final String RESOURCE_LOCATION = "classpath*:public/_schemas/*.json";
 
 
 	public enum GraphDatabaseProvider {

--- a/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
+++ b/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
@@ -5,5 +5,9 @@ import io.opensaber.registry.middleware.MiddlewareHaltException;
 public interface IValidate {
 
 	boolean validate(String entityType, String payload) throws MiddlewareHaltException;
+	/**
+     * Store all list of known definitions as definitionMap.
+     * Must get populated before creating the schema.
+     */
 	void addDefinitions(String definitionTitle, String definitionContent);
 }

--- a/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
+++ b/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
@@ -4,10 +4,14 @@ import io.opensaber.registry.middleware.MiddlewareHaltException;
 
 public interface IValidate {
 
-	boolean validate(String entityType, String payload) throws MiddlewareHaltException;
-	/**
+    boolean validate(String entityType, String payload) throws MiddlewareHaltException;
+
+    /**
      * Store all list of known definitions as definitionMap.
      * Must get populated before creating the schema.
+     * 
+     * @param definitionTitle
+     * @param definitionContent
      */
-	void addDefinitions(String definitionTitle, String definitionContent);
+    void addDefinitions(String definitionTitle, String definitionContent);
 }

--- a/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
+++ b/java/middleware/registry-middleware/validation/src/main/java/io/opensaber/validators/IValidate.java
@@ -5,4 +5,5 @@ import io.opensaber.registry.middleware.MiddlewareHaltException;
 public interface IValidate {
 
 	boolean validate(String entityType, String payload) throws MiddlewareHaltException;
+	void addDefinitions(String definitionTitle, String definitionContent);
 }

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -176,15 +176,14 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	
     @Bean
     public IValidate validationServiceImpl() throws IOException, CustomException {
-        //IValidate validator = null;
         // depends on input type,we need to implement validation
         if (getValidationType() == SchemaType.JSON) {
             IValidate validator = new JsonValidationServiceImpl();
-            logger.info("adding resources to validator service: ");
             definitionsManager.getAllDefinitions().forEach(definition->{
-                logger.info("Definition: title-"+definition.getTitle()+ " , content-"+definition.getContent());
+                logger.debug("Definition: title-" + definition.getTitle() + " , content-" + definition.getContent());
                 validator.addDefinitions(definition.getTitle(), definition.getContent());  
             });
+            logger.info(definitionsManager.getAllDefinitions().size() + " definitions added to validator service ");
             return validator;
         } else {
             logger.error("Fatal - not a known validator mentioned in the application configuration.");

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -26,6 +26,7 @@ import io.opensaber.registry.transform.Json2LdTransformer;
 import io.opensaber.registry.transform.Ld2JsonTransformer;
 import io.opensaber.registry.transform.Ld2LdTransformer;
 import io.opensaber.registry.transform.Transformer;
+import io.opensaber.registry.util.DefinitionsManager;
 import io.opensaber.validators.IValidate;
 import io.opensaber.validators.ValidationFilter;
 import io.opensaber.validators.json.jsonschema.JsonValidationServiceImpl;
@@ -57,6 +58,8 @@ import org.springframework.web.servlet.resource.PathResourceResolver;
 public class GenericConfiguration implements WebMvcConfigurer {
 
 	private static Logger logger = LoggerFactory.getLogger(GenericConfiguration.class);
+	@Autowired
+	private DefinitionsManager definitionsManager;
 
 	@Autowired
 	private Environment environment;
@@ -170,17 +173,23 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	public Middleware authorizationFilter() {
 		return new AuthorizationFilter(new KeyCloakServiceImpl());
 	}
-
+	
     @Bean
     public IValidate validationServiceImpl() throws IOException, CustomException {
-        IValidate validator = null;
+        //IValidate validator = null;
         // depends on input type,we need to implement validation
         if (getValidationType() == SchemaType.JSON) {
-            validator = new JsonValidationServiceImpl();
+            IValidate validator = new JsonValidationServiceImpl();
+            logger.info("adding resources to validator service: ");
+            definitionsManager.getAllDefinitions().forEach(definition->{
+                logger.info("Definition: title-"+definition.getTitle()+ " , content-"+definition.getContent());
+                validator.addDefinitions(definition.getTitle(), definition.getContent());  
+            });
+            return validator;
         } else {
             logger.error("Fatal - not a known validator mentioned in the application configuration.");
         }
-        return validator;
+        return null; 
     }
     
 	@Bean

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
@@ -18,15 +18,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
 @Component("definitionsManager")
 public class DefinitionsManager {
     private static Logger logger = LoggerFactory.getLogger(DefinitionsManager.class);
 
-    @Autowired
-    ResourceLoader resourceLoader;
     @Autowired
     private DefinitionsReader definitionsReader;
     private Map<String, Definition> definitionMap = new HashMap<>();

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
@@ -99,7 +99,7 @@ public class DefinitionsManager {
             InputStream is = resource.getInputStream();
             byte[] encoded = IOUtils.toByteArray(is);
             content = new String(encoded, Charset.forName("UTF-8"));
-            logger.debug(resource.getFilename()+" loaded content: " + content);  
+            logger.debug(resource.getFilename() + " loaded content: " + content);  
             
         } catch (IOException e) {
             logger.error("Cannot load resource " + resource.getFilename());

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
@@ -37,7 +37,7 @@ public class DefinitionsManager {
         
         final ObjectMapper mapper = new ObjectMapper();
         Resource[] resources = definitionsReader.getResources(Constants.RESOURCE_LOCATION);
-        logger.info("Raw resource(s): " + resources.length);
+        logger.info("Count of definitions loaded: " + resources.length);
 
         for (Resource resource : resources) {
             String jsonContent = getContent(resource);
@@ -96,7 +96,6 @@ public class DefinitionsManager {
             InputStream is = resource.getInputStream();
             byte[] encoded = IOUtils.toByteArray(is);
             content = new String(encoded, Charset.forName("UTF-8"));
-            logger.debug(resource.getFilename() + " loaded content: " + content);  
             
         } catch (IOException e) {
             logger.error("Cannot load resource " + resource.getFilename());

--- a/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsManagerTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsManagerTest.java
@@ -28,7 +28,7 @@ public class DefinitionsManagerTest {
         boolean flag = false;
         try {
             int nDefinitions = definitionsManager.getAllKnownDefinitions().size();
-            int nResources = definitionsReader.getResources("classpath:public/_schemas/*.json").length;
+            int nResources = definitionsReader.getResources(Constants.RESOURCE_LOCATION).length;
             flag = (nDefinitions == nResources);
         } catch (IOException ioe) {
 

--- a/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/util/DefinitionsReaderTest.java
@@ -25,7 +25,7 @@ public class DefinitionsReaderTest {
     public void whenAtLeastOneDefinitionPresent_Then_ok() {
         Resource[] resources = null;
         try {
-            resources = definitionsReader.getResources("classpath:public/_schemas/*.json");
+            resources = definitionsReader.getResources(Constants.RESOURCE_LOCATION);
         } catch (IOException ioe) {
             assertFalse(true);
         }

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -56,10 +56,13 @@ public class JsonValidationServiceImpl implements IValidate {
 		}
 		return result;
 	}
-	/**
-	 * Store all list of known definitions as definitionMap.
-	 * Must get populated before creating the schema.
-	 */
+    /**
+     * Store all list of known definitions as definitionMap.
+     * Must get populated before creating the schema.
+     * 
+     * @param definitionTitle
+     * @param definitionContent
+     */
     @Override
     public void addDefinitions(String definitionTitle, String definitionContent) {
         definitionMap.put(definitionTitle, definitionContent);

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -56,7 +56,10 @@ public class JsonValidationServiceImpl implements IValidate {
 		}
 		return result;
 	}
-
+	/**
+	 * Store all list of known definitions as definitionMap.
+	 * Must get populated before creating the schema.
+	 */
     @Override
     public void addDefinitions(String definitionTitle, String definitionContent) {
         if( definitionMap != null ){

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -14,14 +14,8 @@ import org.slf4j.LoggerFactory;
 public class JsonValidationServiceImpl implements IValidate {
 	private static Logger logger = LoggerFactory.getLogger(JsonValidationServiceImpl.class);
 
-	//private ResourceLoader resourceLoader;
 	private Map<String, Schema> entitySchemaMap = new HashMap<>();
 	private Map<String, String> definitionMap;
-
-	/*@Autowired
-	public void setResourceLoader(ResourceLoader resourceLoader) {
-		this.resourceLoader = resourceLoader;
-	}*/
 
 	private Schema getEntitySchema(String entityType) throws MiddlewareHaltException {
 
@@ -30,7 +24,6 @@ public class JsonValidationServiceImpl implements IValidate {
 		} else {
 			Schema schema;
 			try {
-
 				String definitionContent = definitionMap.get(entityType);
                 JSONObject rawSchema = new JSONObject(definitionContent);
 

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -1,42 +1,27 @@
 package io.opensaber.validators.json.jsonschema;
 
-import java.io.IOException;
-import java.io.InputStream;
+import io.opensaber.registry.middleware.MiddlewareHaltException;
+import io.opensaber.validators.IValidate;
 import java.util.HashMap;
 import java.util.Map;
-
-import io.opensaber.pojos.APIMessage;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
-
-
-import io.opensaber.pojos.ValidationResponse;
-import io.opensaber.registry.middleware.MiddlewareHaltException;
-import io.opensaber.validators.IValidate;
 import org.json.JSONObject;
-import org.json.JSONTokener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mail.MailProperties;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
-import org.springframework.web.context.support.ServletContextResource;
-
-import javax.servlet.ServletContext;
 
 public class JsonValidationServiceImpl implements IValidate {
 	private static Logger logger = LoggerFactory.getLogger(JsonValidationServiceImpl.class);
 
-	private ResourceLoader resourceLoader;
+	//private ResourceLoader resourceLoader;
 	private Map<String, Schema> entitySchemaMap = new HashMap<>();
+	private Map<String, String> definitionMap;
 
-	@Autowired
+	/*@Autowired
 	public void setResourceLoader(ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;
-	}
+	}*/
 
 	private Schema getEntitySchema(String entityType) throws MiddlewareHaltException {
 
@@ -45,16 +30,17 @@ public class JsonValidationServiceImpl implements IValidate {
 		} else {
 			Schema schema;
 			try {
-				Resource resource = resourceLoader.getResource("classpath:/public/_schemas/" + entityType + ".json");
-				InputStream schemaStream = resource.getInputStream();
 
-				JSONObject rawSchema = new JSONObject(new JSONTokener(schemaStream));
+				String definitionContent = definitionMap.get(entityType);
+                JSONObject rawSchema = new JSONObject(definitionContent);
+
 				SchemaLoader schemaLoader = SchemaLoader.builder().schemaJson(rawSchema).draftV7Support()
 						.resolutionScope("http://localhost:8080/_schemas/").build();
 				schema = schemaLoader.load().build();
 				entitySchemaMap.put(entityType, schema);
-			} catch (IOException ioe) {
-				throw new MiddlewareHaltException("can't validate");
+			} catch (Exception ioe) {
+			    ioe.printStackTrace();
+				throw new MiddlewareHaltException("can't validate, "+ entityType + ": schema has a problem!");
 			}
 			return schema;
 		}
@@ -77,5 +63,15 @@ public class JsonValidationServiceImpl implements IValidate {
 		}
 		return result;
 	}
+
+    @Override
+    public void addDefinitions(String definitionTitle, String definitionContent) {
+        if( definitionMap != null ){
+            definitionMap.putIfAbsent(definitionTitle, definitionContent);
+        } else {
+            definitionMap = new HashMap<>();
+        }
+        
+    }
 
 }

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -15,7 +15,7 @@ public class JsonValidationServiceImpl implements IValidate {
 	private static Logger logger = LoggerFactory.getLogger(JsonValidationServiceImpl.class);
 
 	private Map<String, Schema> entitySchemaMap = new HashMap<>();
-	private Map<String, String> definitionMap;
+	private Map<String, String> definitionMap = new HashMap<>();;
 
 	private Schema getEntitySchema(String entityType) throws MiddlewareHaltException {
 
@@ -62,12 +62,8 @@ public class JsonValidationServiceImpl implements IValidate {
 	 */
     @Override
     public void addDefinitions(String definitionTitle, String definitionContent) {
-        if( definitionMap != null ){
-            definitionMap.putIfAbsent(definitionTitle, definitionContent);
-        } else {
-            definitionMap = new HashMap<>();
-        }
-        
+        definitionMap.put(definitionTitle, definitionContent);
+       
     }
 
 }


### PR DESCRIPTION
This PR is to connect the input validation (json schema validation) to re-use definitions manager. Perhaps, at the time of validation the list of definitions or the schema file content could be passed, instead of asking the validation layer to read the file contents again.
Also, as found that the resource definitions weren't loaded in Unix boxes. The path to refer to the java resources seems not uniform or incorrectly mentioned in code. This is being fixed as a part of this PR(https://stackoverflow.com/questions/48403184/classpathresource-file-not-found-exception-when-running-the-jar),also used to read the resource as streams.