### PR TITLE
Os 176 Bug while creating index for databaseProvider 

### DIFF
--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -31,6 +31,7 @@ public class Constants {
 	
 	// Parent Vertex Properies
 	public static final String INDEX_FIELDS = "indexFields";
+	public static final String UNIQUE_INDEX_FIELDS ="uniqueIndexFields";
 
 
 	// Configuration constants

--- a/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
+++ b/java/middleware-commons/src/main/java/io/opensaber/registry/middleware/util/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
 	
 	// Parent Vertex Properies
 	public static final String INDEX_FIELDS = "indexFields";
-	public static final String UNIQUE_INDEX_FIELDS ="uniqueIndexFields";
+	public static final String UNIQUE_INDEX_FIELDS = "uniqueIndexFields";
 
 
 	// Configuration constants

--- a/java/registry/src/main/java/io/opensaber/registry/app/AppStartupRunner.java
+++ b/java/registry/src/main/java/io/opensaber/registry/app/AppStartupRunner.java
@@ -21,5 +21,7 @@ public class AppStartupRunner implements ApplicationRunner {
     public void run(ApplicationArguments args) throws Exception {
     	logger.info("On Boot starts loading: parent vertex and shard records");
     	entityParenter.ensureKnownParenters();
+    	entityParenter.loadDefinitionIndex();
+    	entityParenter.ensureIndexExists();
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
@@ -132,7 +132,6 @@ public class VertexReader {
                 } else {
                     logger.debug("{} is a simple value", prop.key());
                     if (canAdd(prop.key(), privatePropertyList)) {
-                        String propValue = prop.value().toString();
                         if (propValue.contains(",")) {
                             ArrayNode stringArray = JsonNodeFactory.instance.arrayNode();
                             String[] valArray = propValue.split(",");

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexReader.java
@@ -8,6 +8,7 @@ import io.opensaber.registry.exception.RecordNotFoundException;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.middleware.util.JSONUtil;
 import io.opensaber.registry.sink.DatabaseProvider;
+import io.opensaber.registry.util.ArrayHelper;
 import io.opensaber.registry.util.Definition;
 import io.opensaber.registry.util.DefinitionsManager;
 import io.opensaber.registry.util.ReadConfigurator;
@@ -106,6 +107,7 @@ public class VertexReader {
         Iterator<VertexProperty<Object>> properties = currVertex.properties();
         while (properties.hasNext()) {
             VertexProperty<Object> prop = properties.next();
+            String propValue = ArrayHelper.removeSquareBraces(prop.value().toString());
             if (!RefLabelHelper.isParentLabel(prop.key())) {
                 if (RefLabelHelper.isRefLabel(prop.key(), uuidPropertyName)) {
                     logger.debug("{} is a referenced entity", prop.key());
@@ -113,7 +115,7 @@ public class VertexReader {
                     // otherwise.
 
                     String refEntityName = RefLabelHelper.getRefEntityName(prop.key());
-                    String[] valueArr = prop.value().toString().split("\\s*,\\s*");
+                    String[] valueArr = propValue.split("\\s*,\\s*");
                     boolean isObjectNode = valueArr.length == 1;
 
                     ArrayNode arrayNode = JsonNodeFactory.instance.arrayNode();

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.sink.DatabaseProvider;
+import io.opensaber.registry.util.ArrayHelper;
 import io.opensaber.registry.util.RefLabelHelper;
 import io.opensaber.registry.util.TypePropertyHelper;
 import java.util.ArrayList;
@@ -17,7 +18,6 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 public class VertexWriter {
     private String uuidPropertyName;
@@ -119,9 +119,9 @@ public class VertexWriter {
         // Set up references on a blank node.
         label = RefLabelHelper.getLabel(entryKey, uuidPropertyName);
         if (isArrayItemObject) {
-            blankNode.property(label, StringUtils.arrayToCommaDelimitedString(uidList.toArray()));
+            blankNode.property(label, ArrayHelper.formatToString(uidList));
         } else {
-            blankNode.property(entryKey, StringUtils.arrayToCommaDelimitedString(uidList.toArray()));
+            blankNode.property(entryKey, ArrayHelper.formatToString(uidList));
         }
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
@@ -23,7 +23,7 @@ public class VertexWriter {
     private String uuidPropertyName;
     private DatabaseProvider databaseProvider;
     private String parentOSid;
-    private static final String EMPTY = "";
+    private static final String EMPTY_STR = "";
 
     private Logger logger = LoggerFactory.getLogger(VertexWriter.class);
 
@@ -48,7 +48,8 @@ public class VertexWriter {
         if (!iterVertex.hasNext()) {
             parentVertex = createVertex(graph, parentLabel);
             //added a property to track vertices belong to parent are indexed
-            parentVertex.property(Constants.INDEX_FIELDS, EMPTY);
+            parentVertex.property(Constants.INDEX_FIELDS, EMPTY_STR);
+            parentVertex.property(Constants.UNIQUE_INDEX_FIELDS, EMPTY_STR);
             logger.info("Parent label {} created {}", parentLabel, parentVertex.id().toString());
         } else {
             parentVertex = iterVertex.next();

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -201,13 +201,17 @@ public class RegistryServiceImpl implements RegistryService {
      * @param label
      * @throws Exception
      */
-    private void addIndex(DatabaseProvider dbProvider, String shardId, String label) throws Exception{
-        try (OSGraph osGraph = dbProvider.getOSGraph()) {
-            Graph graph = osGraph.getGraphStore();
-            Transaction tx = dbProvider.startTransaction(graph);           
-            ensureIndexExists(graph, dbProvider, shardId, label);
-            dbProvider.commitTransaction(graph, tx);
-        }            
+    private void addIndex(DatabaseProvider dbProvider, String shardId, String label) {
+        new Thread(() -> {
+            try (OSGraph osGraph = dbProvider.getOSGraph()) {
+                Graph graph = osGraph.getGraphStore();
+                Transaction tx = dbProvider.startTransaction(graph);           
+                ensureIndexExists(graph, dbProvider, shardId, label);
+                dbProvider.commitTransaction(graph, tx);
+            } catch (Exception e) {
+              logger.info("Can't create index on table " + label);
+          }
+        }).start();           
     }
 
     /**

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -211,7 +211,7 @@ public class RegistryServiceImpl implements RegistryService {
         List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
         
         IndexHelper indexHelper = new IndexHelper(indexFields, indexUniqueFields, parentVertex);
-        indexHelper.create(dbProvider, label);
+        indexHelper.create(dbProvider, label, uuidPropertyName);
 
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -24,7 +24,7 @@ import io.opensaber.registry.sink.shard.Shard;
 import io.opensaber.registry.util.Definition;
 import io.opensaber.registry.util.DefinitionsManager;
 import io.opensaber.registry.util.EntityParenter;
-import io.opensaber.registry.util.IndexHelper;
+import io.opensaber.registry.util.Indexer;
 import io.opensaber.registry.util.ReadConfigurator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -214,10 +214,10 @@ public class RegistryServiceImpl implements RegistryService {
         // adds default field (uuid)
         indexUniqueFields.add(uuidPropertyName);
 
-        IndexHelper indexHelper = new IndexHelper(dbProvider, parentVertex);
-        indexHelper.setIndexFields(indexFields);
-        indexHelper.setUniqueIndexFields(indexUniqueFields);
-        indexHelper.create(label);
+        Indexer indexer = new Indexer(dbProvider, parentVertex);
+        indexer.setIndexFields(indexFields);
+        indexer.setUniqueIndexFields(indexUniqueFields);
+        indexer.createIndex(label);
 
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -214,10 +214,10 @@ public class RegistryServiceImpl implements RegistryService {
         // adds default field (uuid)
         indexUniqueFields.add(uuidPropertyName);
 
-        Indexer indexer = new Indexer(dbProvider, parentVertex);
+        Indexer indexer = new Indexer(dbProvider);
         indexer.setIndexFields(indexFields);
         indexer.setUniqueIndexFields(indexUniqueFields);
-        indexer.createIndex(label);
+        indexer.createIndex(label, parentVertex);
 
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -188,10 +188,11 @@ public class RegistryServiceImpl implements RegistryService {
 
                 vertexLabel = rootNode.fieldNames().next();
             }
-            //Add indices: executed only once.
-            Vertex parentVertex = entityParenter.getKnownParentVertex(vertexLabel, shard.getShardId());
+            //Add indices: executes only once.
+            String shardId = shard.getShardId();
+            Vertex parentVertex = entityParenter.getKnownParentVertex(vertexLabel, shardId);
             Definition definition = definitionsManager.getDefinition(vertexLabel);
-            entityParenter.ensureIndexExists(dbProvider, parentVertex, definition);
+            entityParenter.ensureIndexExists(dbProvider, parentVertex, definition, shardId);
         }
 
         return entityId;

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -196,22 +196,28 @@ public class RegistryServiceImpl implements RegistryService {
     }
 
     /**
-     * Ensures index for a vertex exists 
-     * Unique index and non-unique index is supported
+     * Ensures index for a vertex exists Unique index and non-unique index is
+     * supported
+     * 
      * @param dbProvider
-     * @param graph
-     * @param label   a type vertex label (example:Teacher)
+     * @param shardId
+     * @param label
+     *            a type vertex label (example:Teacher)
      */
     private void ensureIndexExists(DatabaseProvider dbProvider, String shardId, String label) {
 
         Vertex parentVertex = entityParenter.getKnownParentVertex(label, shardId);
         Definition definition = definitionsManager.getDefinition(label);
-        
+
         List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
         List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
-        
-        IndexHelper indexHelper = new IndexHelper(indexFields, indexUniqueFields, parentVertex);
-        indexHelper.create(dbProvider, label, uuidPropertyName);
+        // adds default field (uuid)
+        indexUniqueFields.add(uuidPropertyName);
+
+        IndexHelper indexHelper = new IndexHelper(dbProvider, parentVertex);
+        indexHelper.setIndexFields(indexFields);
+        indexHelper.setUniqueIndexFields(indexUniqueFields);
+        indexHelper.create(label);
 
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
@@ -152,13 +152,13 @@ public abstract class DatabaseProvider {
     /**
      * Creates index
      */
-    public void createIndex(String label, List<String> propertyNames){
+    public void createIndex(Graph graph, String label, List<String> propertyNames){
         //Does nothing, suppose to be overridden by extended classes.
     }
     /**
      * Creates unique index
      */
-    public void createUniqueIndex(String label, List<String> propertyNames){
+    public void createUniqueIndex(Graph graph, String label, List<String> propertyNames){
         //Does nothing, suppose to be overridden by extended classes.
     }
         

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -26,8 +26,6 @@ public class Neo4jGraphProvider extends DatabaseProvider {
     private boolean profilerEnabled;
     private DBConnectionInfo connectionInfo;
     private Neo4jIdProvider neo4jIdProvider = new Neo4jIdProvider();
-    private Neo4JGraph neo4jGraph;
-
 
 	public Neo4jGraphProvider(DBConnectionInfo connection, String uuidPropName) {
 		connectionInfo = connection;
@@ -42,6 +40,7 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 	}
 
     private Neo4JGraph getGraph() {
+        Neo4JGraph neo4jGraph;
         Neo4JElementIdProvider<?> idProvider = neo4jIdProvider;
 
         neo4jGraph = new Neo4JGraph(driver, idProvider, idProvider);
@@ -102,10 +101,15 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 	
 	@Override
 	public void createIndex(String label, List<String> propertyNames){
+
+	    Neo4JGraph neo4jGraph = getGraph();
+        Transaction tx = startTransaction(neo4jGraph);
+
 	    for(String propertyName : propertyNames){
 	        neo4jGraph.createIndex(label, propertyName);
             logger.info("Neo4jGraph index created for " + label);
-
 	    }
+        commitTransaction(neo4jGraph, tx);
+
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -26,6 +26,8 @@ public class Neo4jGraphProvider extends DatabaseProvider {
     private boolean profilerEnabled;
     private DBConnectionInfo connectionInfo;
     private Neo4jIdProvider neo4jIdProvider = new Neo4jIdProvider();
+    private Neo4JGraph neo4jGraph;
+
 
 	public Neo4jGraphProvider(DBConnectionInfo connection, String uuidPropName) {
 		connectionInfo = connection;
@@ -40,7 +42,6 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 	}
 
     private Neo4JGraph getGraph() {
-        Neo4JGraph neo4jGraph;
         Neo4JElementIdProvider<?> idProvider = neo4jIdProvider;
 
         neo4jGraph = new Neo4JGraph(driver, idProvider, idProvider);
@@ -101,9 +102,10 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 	
 	@Override
 	public void createIndex(String label, List<String> propertyNames){
-	    Neo4JGraph neo4jGraph = getGraph();
 	    for(String propertyName : propertyNames){
 	        neo4jGraph.createIndex(label, propertyName);
+            logger.info("Neo4jGraph index created for " + label);
+
 	    }
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -27,17 +27,17 @@ public class Neo4jGraphProvider extends DatabaseProvider {
     private DBConnectionInfo connectionInfo;
     private Neo4jIdProvider neo4jIdProvider = new Neo4jIdProvider();
 
-	public Neo4jGraphProvider(DBConnectionInfo connection, String uuidPropName) {
-		connectionInfo = connection;
-		profilerEnabled = connection.isProfilerEnabled();
-		setProvider(Constants.GraphDatabaseProvider.NEO4J);
-		setUuidPropertyName(uuidPropName);
+    public Neo4jGraphProvider(DBConnectionInfo connection, String uuidPropName) {
+        connectionInfo = connection;
+        profilerEnabled = connection.isProfilerEnabled();
+        setProvider(Constants.GraphDatabaseProvider.NEO4J);
+        setUuidPropertyName(uuidPropName);
 
-		// TODO: Check with auth
-		driver = GraphDatabase.driver(connection.getUri(), AuthTokens.none());
-		neo4jIdProvider.setUuidPropertyName(getUuidPropertyName());
-		logger.info("Initialized db driver at {}", connectionInfo.getUri());
-	}
+        // TODO: Check with auth
+        driver = GraphDatabase.driver(connection.getUri(), AuthTokens.none());
+        neo4jIdProvider.setUuidPropertyName(getUuidPropertyName());
+        logger.info("Initialized db driver at {}", connectionInfo.getUri());
+    }
 
     private Neo4JGraph getGraph() {
         Neo4JGraph neo4jGraph;
@@ -48,68 +48,70 @@ public class Neo4jGraphProvider extends DatabaseProvider {
         return neo4jGraph;
     }
 
-	@PostConstruct
-	public void init() {
-		logger.info("**************************************************************************");
-		logger.info("Initializing Neo4J GraphDB instance ...");
-		logger.info("**************************************************************************");
-	}
+    @PostConstruct
+    public void init() {
+        logger.info("**************************************************************************");
+        logger.info("Initializing Neo4J GraphDB instance ...");
+        logger.info("**************************************************************************");
+    }
 
     @PreDestroy
     public void shutdown() throws Exception {
-		logger.info("**************************************************************************");
-		logger.info("Gracefully shutting down Neo4J GraphDB instance ...");
-		logger.info("**************************************************************************");
-	}
+        logger.info("**************************************************************************");
+        logger.info("Gracefully shutting down Neo4J GraphDB instance ...");
+        logger.info("**************************************************************************");
+    }
 
-	@Override
-	public OSGraph getOSGraph() {
-		Graph graph = getGraph();
-		return new OSGraph(graph, true);
-	}
+    @Override
+    public OSGraph getOSGraph() {
+        Graph graph = getGraph();
+        return new OSGraph(graph, true);
+    }
 
-	@Override
-	public void commitTransaction(Graph graph, Transaction tx) {
-		commitTransaction(graph, tx, true);
-	}
+    @Override
+    public void commitTransaction(Graph graph, Transaction tx) {
+        commitTransaction(graph, tx, true);
+    }
 
-	/**
-	 * For neo4j, we would like to use the Neo4JIdProvider
-	 * @param o - any record object
-	 * @return
-	 */
-	@Override
-	public String generateId(Object o) {
-		if (o instanceof Neo4JVertex) {
-			return ((Neo4JVertex) o).id().toString();
-		} else if (o instanceof Neo4JEdge) {
-			return ((Neo4JEdge) o).id().toString();
-		}
+    /**
+     * For neo4j, we would like to use the Neo4JIdProvider
+     * 
+     * @param o
+     *            - any record object
+     * @return
+     */
+    @Override
+    public String generateId(Object o) {
+        if (o instanceof Neo4JVertex) {
+            return ((Neo4JVertex) o).id().toString();
+        } else if (o instanceof Neo4JEdge) {
+            return ((Neo4JEdge) o).id().toString();
+        }
 
-		throw new RuntimeException(o.getClass().getTypeName() + " cannot have an id");
-	}
+        throw new RuntimeException(o.getClass().getTypeName() + " cannot have an id");
+    }
 
-	@Override
-	public String getId(Vertex vertex) {
-		return vertex.id().toString();
-	}
+    @Override
+    public String getId(Vertex vertex) {
+        return vertex.id().toString();
+    }
 
-	@Override
-	public String getId(Edge edge) {
-		return edge.id().toString();
-	}
-	
-	@Override
-	public void createIndex(String label, List<String> propertyNames){
+    @Override
+    public String getId(Edge edge) {
+        return edge.id().toString();
+    }
 
-	    Neo4JGraph neo4jGraph = getGraph();
+    @Override
+    public void createIndex(String label, List<String> propertyNames) {
+
+        Neo4JGraph neo4jGraph = getGraph();
         Transaction tx = startTransaction(neo4jGraph);
 
-	    for(String propertyName : propertyNames){
-	        neo4jGraph.createIndex(label, propertyName);
+        for (String propertyName : propertyNames) {
+            neo4jGraph.createIndex(label, propertyName);
             logger.info("Neo4jGraph index created for " + label);
-	    }
+        }
         commitTransaction(neo4jGraph, tx);
 
-	}
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -102,16 +102,14 @@ public class Neo4jGraphProvider extends DatabaseProvider {
     }
 
     @Override
-    public void createIndex(String label, List<String> propertyNames) {
+    public void createIndex(Graph graph,String label, List<String> propertyNames) {
 
-        Neo4JGraph neo4jGraph = getGraph();
-        Transaction tx = startTransaction(neo4jGraph);
-
+        Neo4JGraph neo4jGraph = (Neo4JGraph) graph;
+        
         for (String propertyName : propertyNames) {
             neo4jGraph.createIndex(label, propertyName);
             logger.info("Neo4jGraph index created for " + label);
         }
-        commitTransaction(neo4jGraph, tx);
-
+        
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -20,73 +20,75 @@ import org.umlg.sqlg.structure.topology.VertexLabel;
 
 public class SqlgProvider extends DatabaseProvider {
 
-	private Logger logger = LoggerFactory.getLogger(SqlgProvider.class);
-	private SqlgGraph graph;
-	private OSGraph customGraph;
+    private Logger logger = LoggerFactory.getLogger(SqlgProvider.class);
+    private SqlgGraph graph;
+    private OSGraph customGraph;
 
-	public SqlgProvider(DBConnectionInfo connectionInfo, String uuidPropertyName) {
-		Configuration config = new BaseConfiguration();
-		config.setProperty("jdbc.url", connectionInfo.getUri());
-		config.setProperty("jdbc.username", connectionInfo.getUsername());
-		config.setProperty("jdbc.password", connectionInfo.getPassword());
-		setProvider(Constants.GraphDatabaseProvider.SQLG);
-		setUuidPropertyName(uuidPropertyName);
-		graph = SqlgGraph.open(config);
-		customGraph = new OSGraph(graph, false);
-	}
+    public SqlgProvider(DBConnectionInfo connectionInfo, String uuidPropertyName) {
+        Configuration config = new BaseConfiguration();
+        config.setProperty("jdbc.url", connectionInfo.getUri());
+        config.setProperty("jdbc.username", connectionInfo.getUsername());
+        config.setProperty("jdbc.password", connectionInfo.getPassword());
+        setProvider(Constants.GraphDatabaseProvider.SQLG);
+        setUuidPropertyName(uuidPropertyName);
+        graph = SqlgGraph.open(config);
+        customGraph = new OSGraph(graph, false);
+    }
 
-	@PostConstruct
-	public void init() {
-		logger.info("**************************************************************************");
-		logger.info("Initializing SQLG DB instance ...");
-		logger.info("**************************************************************************");
-	}
+    @PostConstruct
+    public void init() {
+        logger.info("**************************************************************************");
+        logger.info("Initializing SQLG DB instance ...");
+        logger.info("**************************************************************************");
+    }
 
-	@PreDestroy
-	public void shutdown() throws Exception {
-		logger.info("**************************************************************************");
-		logger.info("Gracefully shutting down SQLG DB instance ...");
-		logger.info("**************************************************************************");
-		graph.close();
-	}
+    @PreDestroy
+    public void shutdown() throws Exception {
+        logger.info("**************************************************************************");
+        logger.info("Gracefully shutting down SQLG DB instance ...");
+        logger.info("**************************************************************************");
+        graph.close();
+    }
 
-	@Override
-	public OSGraph getOSGraph() {
-		return customGraph;
-	}
+    @Override
+    public OSGraph getOSGraph() {
+        return customGraph;
+    }
 
-	@Override
-	public String getId(Vertex vertex) {
-		return (String) vertex.property(getUuidPropertyName()).value();
-	}
-	
-	@Override
-	public void createIndex(String label, List<String> propertyNames){	  
-	    createIndexByIndexType(IndexType.NON_UNIQUE, label, propertyNames);
-	}
-	
-	@Override
-	public void createUniqueIndex(String label, List<String> propertyNames){
-	    createIndexByIndexType(IndexType.UNIQUE, label, propertyNames);
-	}
-	/**
-	 * creates sqlg index for a given index type(unique/non-unique)
-	 * @param indexType
-	 * @param label
-	 * @param propertyNames
-	 */
-	private void createIndexByIndexType(IndexType indexType, String label, List<String> propertyNames){
-	    Transaction tx = startTransaction(graph);
-        VertexLabel vertexLabel = graph.getTopology().ensureVertexLabelExist(label);  
+    @Override
+    public String getId(Vertex vertex) {
+        return (String) vertex.property(getUuidPropertyName()).value();
+    }
+
+    @Override
+    public void createIndex(String label, List<String> propertyNames) {
+        createIndexByIndexType(IndexType.NON_UNIQUE, label, propertyNames);
+    }
+
+    @Override
+    public void createUniqueIndex(String label, List<String> propertyNames) {
+        createIndexByIndexType(IndexType.UNIQUE, label, propertyNames);
+    }
+
+    /**
+     * creates sqlg index for a given index type(unique/non-unique)
+     * 
+     * @param indexType
+     * @param label
+     * @param propertyNames
+     */
+    private void createIndexByIndexType(IndexType indexType, String label, List<String> propertyNames) {
+        Transaction tx = startTransaction(graph);
+        VertexLabel vertexLabel = graph.getTopology().ensureVertexLabelExist(label);
         List<PropertyColumn> properties = new ArrayList<>();
         for (String propertyName : propertyNames) {
             properties.add(vertexLabel.getProperty(propertyName).get());
         }
-        if(properties.size()>0){
+        if (properties.size() > 0) {
             Index index = vertexLabel.ensureIndexExists(indexType, properties);
-            logger.info(indexType + "index created for " + label + " - "+index.getName());
+            logger.info(indexType + "index created for " + label + " - " + index.getName());
         }
         commitTransaction(graph, tx);
 
-	}
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -8,7 +8,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,25 +61,24 @@ public class SqlgProvider extends DatabaseProvider {
     }
 
     @Override
-    public void createIndex(String label, List<String> propertyNames) {
-        createIndexByIndexType(IndexType.NON_UNIQUE, label, propertyNames);
+    public void createIndex(Graph graph, String label, List<String> propertyNames) {
+        createIndexByIndexType(graph, IndexType.NON_UNIQUE, label, propertyNames);
     }
 
     @Override
-    public void createUniqueIndex(String label, List<String> propertyNames) {
-        createIndexByIndexType(IndexType.UNIQUE, label, propertyNames);
+    public void createUniqueIndex(Graph graph, String label, List<String> propertyNames) {
+        createIndexByIndexType(graph, IndexType.UNIQUE, label, propertyNames);
     }
 
     /**
      * creates sqlg index for a given index type(unique/non-unique)
-     * 
+     * @param graph
      * @param indexType
      * @param label
      * @param propertyNames
      */
-    private void createIndexByIndexType(IndexType indexType, String label, List<String> propertyNames) {
-        Transaction tx = startTransaction(graph);
-        VertexLabel vertexLabel = graph.getTopology().ensureVertexLabelExist(label);
+    private void createIndexByIndexType(Graph graph, IndexType indexType, String label, List<String> propertyNames) {
+        VertexLabel vertexLabel = ((SqlgGraph) graph).getTopology().ensureVertexLabelExist(label);
         List<PropertyColumn> properties = new ArrayList<>();
         for (String propertyName : propertyNames) {
             properties.add(vertexLabel.getProperty(propertyName).get());
@@ -88,7 +87,6 @@ public class SqlgProvider extends DatabaseProvider {
             Index index = vertexLabel.ensureIndexExists(indexType, properties);
             logger.info(indexType + "index created for " + label + " - " + index.getName());
         }
-        commitTransaction(graph, tx);
 
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -8,6 +8,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,7 @@ public class SqlgProvider extends DatabaseProvider {
 	 * @param propertyNames
 	 */
 	private void createIndexByIndexType(IndexType indexType, String label, List<String> propertyNames){
+	    Transaction tx = startTransaction(graph);
         VertexLabel vertexLabel = graph.getTopology().ensureVertexLabelExist(label);  
         List<PropertyColumn> properties = new ArrayList<>();
         for (String propertyName : propertyNames) {
@@ -84,5 +86,7 @@ public class SqlgProvider extends DatabaseProvider {
             Index index = vertexLabel.ensureIndexExists(indexType, properties);
             logger.info(indexType + "index created for " + label + " - "+index.getName());
         }
+        commitTransaction(graph, tx);
+
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -79,7 +79,7 @@ public class EntityParenter {
                             Vertex v = vertexWriter.ensureParentVertex(graph, parentLabel);
 
                             //adding index to shard
-                            logger.info("Adding index to shard: {} for definition: {}",dbConnectionInfo.getShardId(), defintionName );
+                            logger.info("Adding index to shard: {} for definition: {}", dbConnectionInfo.getShardId(), defintionName );
                             Definition definition = definitionsManager.getDefinition(defintionName);
                             ensureIndexExists(dbProvider, v, definition);
                             
@@ -151,12 +151,11 @@ public class EntityParenter {
      */
     public void ensureIndexExists(DatabaseProvider dbProvider, Vertex parentVertex, Definition definition) {
         try{
-            logger.info("definition "+definition.getTitle() );
             if(!indexHelper.isIndexPresent(parentVertex, definition)){
                 asyncAddIndex(dbProvider, parentVertex, definition);
             }
         }catch(Exception e){
-            logger.error("ensureknownparenter: Can't create index on table " + definition.getTitle());
+            logger.error("ensureIndexExists: Can't create index on table {}", definition.getTitle());
         }
        
 

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -187,6 +187,7 @@ public class EntityParenter {
                             Definition definition = definitionsManager.getDefinition(defintionName);
                             ensureIndexExists(dbProvider, v, definition, dbConnectionInfo.getShardId());
                         });
+                        dbProvider.commitTransaction(graph, tx);
                     }
                 }
                 

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -7,9 +7,15 @@ import java.util.List;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Component
 public class IndexHelper {
     private static Logger logger = LoggerFactory.getLogger(IndexHelper.class);
+    
+    @Value("${database.uuidPropertyName}")
+    public String uuidPropertyName;
 
     private List<String> indexFields;
     private List<String> indexUniqueFields;
@@ -20,6 +26,9 @@ public class IndexHelper {
 
     public IndexHelper(List<String> indexFields, List<String> indexUniqueFields, Vertex parentVertex) {
 
+        //Added a default property(uuid)
+        indexFields.add(uuidPropertyName);
+        
         this.indexFields = indexFields;
         this.indexUniqueFields = indexUniqueFields;
         this.parentVertex = parentVertex;

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -18,9 +18,15 @@ public class IndexHelper {
 
     @Autowired
     private DefinitionsManager definitionManager;
-
+    
+    /**
+     * Holds mapping for each definitions and its index status 
+     */
     private Map<String, Boolean> definitionIndexMap = new HashMap<String, Boolean>();
-
+    
+    /**
+     * loads each the definitions with default index status as false
+     */
     @PostConstruct
     public void loadDefinitionIndex() {
         List<Definition> definitions = definitionManager.getAllDefinitions();

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -52,18 +52,15 @@ public class IndexHelper {
      *            a type vertex label (example:Teacher) and table in rdbms
      */
     public void create(String label) {
-
         if (label != null && !label.isEmpty()) {
             createIndex(label);
             createUniqueIndex(label);
         } else {
             logger.info("label is required for creating indexing");
         }
-
     }
 
     private void createIndex(String label) {
-
         try {
             addFields(indexFields, false);
             setPropertyValues(newIndexFields, false);
@@ -73,7 +70,6 @@ public class IndexHelper {
             e.printStackTrace();
             logger.error("On non-unique index creation " + e);
         }
-
     }
 
     private void createUniqueIndex(String label) {
@@ -103,7 +99,7 @@ public class IndexHelper {
             if (!values.contains(field))
                 newFields.add(field);
         }
-        logger.info("No of fields to add index are {}", propertyName + newFields.size());
+        logger.info("No of fields to add {} ", propertyName + newFields.size());
     }
 
     /**

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -1,0 +1,95 @@
+package io.opensaber.registry.util;
+
+import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.sink.DatabaseProvider;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IndexHelper {
+    private static Logger logger = LoggerFactory.getLogger(IndexHelper.class);
+
+    private List<String> indexFields;
+    private List<String> indexUniqueFields;
+    private Vertex parentVertex;
+
+    private List<String> newIndexFields = new ArrayList<>();
+    private List<String> newIndexUniqueFields = new ArrayList<>();
+
+    public IndexHelper(List<String> indexFields, List<String> indexUniqueFields, Vertex parentVertex) {
+
+        this.indexFields = indexFields;
+        this.indexUniqueFields = indexUniqueFields;
+        this.parentVertex = parentVertex;
+
+    }
+
+    /**
+     * Creates index for a given databaseProvider  
+     * 
+     * @param dbProvider
+     * @param label     a type vertex label (example:Teacher)
+     */
+    public void create(DatabaseProvider dbProvider, String label) {
+
+        try {
+            // creates non-unique index
+            addFields(indexFields, false);
+            setPropertyValues(newIndexFields, false); 
+            dbProvider.createIndex(label, newIndexFields);
+            
+            //creates unique index
+            addFields(indexUniqueFields, true);
+            setPropertyValues(newIndexUniqueFields, true);
+            dbProvider.createUniqueIndex(label, newIndexUniqueFields);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.error("On non-unique index creation " + e);
+        }
+        
+    }
+
+    /**
+     * Gives new fields for creating index Parent vertex are always have
+     * INDEX_FIELDS and UNIQUE_INDEX_FIELDS property
+     * 
+     * @param parentVertex
+     * @param fields
+     * @return
+     */
+    private void addFields(List<String> fields, boolean isUnique) {
+        List<String> newFields = isUnique ? newIndexUniqueFields : newIndexFields;
+        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
+        String values = (String) parentVertex.property(propertyName).value();
+        for (String field : fields) {
+            if (!values.contains(field))
+                newFields.add(field);
+        }
+        logger.info("No of fields to add index are {}" , propertyName + newFields.size());
+    }
+
+    /**
+     * Append the values to parent vertex INDEX_FIELDS and UNIQUE_INDEX_FIELDS property
+     * 
+     * @param parentVertex
+     * @param values
+     */
+    private void setPropertyValues(List<String> values, boolean isUnique) {
+
+        if (values.size() > 0) {
+            String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
+            String existingValue = (String) parentVertex.property(propertyName).value();
+            for (String value : values) {
+                existingValue = existingValue.isEmpty() ? value : (existingValue + "," + value);
+                parentVertex.property(propertyName, existingValue);
+            }
+            logger.info("parent vertex property {}:{}", propertyName, existingValue);
+        } else {
+            logger.info("no values to set for parent vertex property ");
+        }
+    }
+
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -1,0 +1,82 @@
+package io.opensaber.registry.util;
+
+import io.opensaber.registry.middleware.util.Constants;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IndexHelper {
+    private static Logger logger = LoggerFactory.getLogger(IndexHelper.class);
+
+    @Autowired
+    private DefinitionsManager definitionManager;
+
+    private Map<String, Boolean> definitionIndexMap = new HashMap<String, Boolean>();
+
+    @PostConstruct
+    public void loadDefinitionIndex() {
+        List<Definition> definitions = definitionManager.getAllDefinitions();
+        definitions.forEach(definition -> {
+            definitionIndexMap.put(definition.getTitle(), false);
+        });
+    }
+
+    /**
+     * Checks any new index available to for index creation
+     * 
+     * @param parentVertex
+     * @param definition
+     * @return
+     */
+    public boolean isIndexPresent(Vertex parentVertex, Definition definition) {
+        boolean isIndexPresent = false;
+        String defTitle = definition.getTitle();
+        logger.info("isIndexPresent flag for {}: {}", defTitle, definitionIndexMap.get(defTitle));
+        if (!definitionIndexMap.get(defTitle)) {
+
+            List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
+            int indexSize = (indexFields.size() == 0) ? 0 : getNewFields(parentVertex, indexFields, false).size();
+            if (indexSize > 0)
+                return isIndexPresent;
+
+            List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
+            int uniqueIndexSize = (indexUniqueFields.size() == 0) ? 0
+                    : getNewFields(parentVertex, indexUniqueFields, true).size();
+            if (uniqueIndexSize > 0)
+                return isIndexPresent;
+
+        }
+        definitionIndexMap.put(defTitle, true);
+        isIndexPresent = true;
+
+        return isIndexPresent;
+    }
+
+    /**
+     * Identifies new fields for creating index. Parent vertex are always have
+     * INDEX_FIELDS and UNIQUE_INDEX_FIELDS property
+     * 
+     * @param parentVertex
+     * @param fields
+     * @param isUnique
+     */
+    public List<String> getNewFields(Vertex parentVertex, List<String> fields, boolean isUnique) {
+        List<String> newFields = new ArrayList<>();
+        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
+        String values = (String) parentVertex.property(propertyName).value();
+        for (String field : fields) {
+            if (!values.contains(field) && !newFields.contains(field))
+                newFields.add(field);
+        }
+        return newFields;
+    }
+
+}

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -13,8 +13,8 @@ import org.slf4j.LoggerFactory;
  * values for unique index & non-unique index fields
  *
  */
-public class IndexHelper {
-    private static Logger logger = LoggerFactory.getLogger(IndexHelper.class);
+public class Indexer {
+    private static Logger logger = LoggerFactory.getLogger(Indexer.class);
 
     private List<String> indexFields;
     private List<String> indexUniqueFields;
@@ -24,7 +24,7 @@ public class IndexHelper {
     private List<String> newIndexFields = new ArrayList<>();
     private List<String> newIndexUniqueFields = new ArrayList<>();
 
-    public IndexHelper(DatabaseProvider databaseProvider, Vertex parentVertex) {
+    public Indexer(DatabaseProvider databaseProvider, Vertex parentVertex) {
         this.databaseProvider = databaseProvider;
         this.parentVertex = parentVertex;
     }

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -95,7 +95,6 @@ public class Indexer {
             if (!values.contains(field))
                 newFields.add(field);
         }
-        logger.info("No of fields to add {} ", propertyName + newFields.size());
     }
 
     /**

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -2,7 +2,6 @@ package io.opensaber.registry.util;
 
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.sink.DatabaseProvider;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -67,9 +66,8 @@ public class Indexer {
 
     private void createNonUniqueIndex(Graph graph, String label, Vertex parentVertex) {
         try {
-            List<String> newIndexFields = getNewFields(parentVertex, indexFields, false);
-            databaseProvider.createIndex(graph, label, newIndexFields);
-            updateIndices(parentVertex, newIndexFields, false);
+            databaseProvider.createIndex(graph, label, indexFields);
+            updateIndices(parentVertex, indexFields, false);
 
         } catch (Exception e) {
             logger.error("Non-unique index creation error: " + e);
@@ -78,32 +76,12 @@ public class Indexer {
 
     private void createUniqueIndex(Graph graph, String label, Vertex parentVertex) {
         try {
-            List<String> newIndexUniqueFields = getNewFields(parentVertex, indexUniqueFields, true);
-            databaseProvider.createUniqueIndex(graph, label, newIndexUniqueFields);
-            updateIndices(parentVertex, newIndexUniqueFields, true);
+            databaseProvider.createUniqueIndex(graph, label, indexUniqueFields);
+            updateIndices(parentVertex, indexUniqueFields, true);
 
         } catch (Exception e) {
             logger.error("Unique index creation error: " + e);
         }
-    }
-
-    /**
-     * Identifies new fields for creating index. Parent vertex are always have
-     * INDEX_FIELDS and UNIQUE_INDEX_FIELDS property
-     * 
-     * @param parentVertex
-     * @param fields
-     * @param isUnique
-     */
-    private List<String> getNewFields(Vertex parentVertex, List<String> fields, boolean isUnique) {
-        List<String> newFields = new ArrayList<>();
-        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
-        String values = (String) parentVertex.property(propertyName).value();
-        for (String field : fields) {
-            if (!values.contains(field))
-                newFields.add(field);
-        }
-        return newFields;
     }
 
     /**

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -3,6 +3,7 @@ package io.opensaber.registry.util;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.sink.DatabaseProvider;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ public class Indexer {
      * @param label     type vertex label (example:Teacher) and table in rdbms           
      * @param parentVertex
      */
-    public void createIndex(Graph graph, String label, Vertex parentVertex) {
+    public void createIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
         if (label != null && !label.isEmpty()) {
             createNonUniqueIndex(graph, label, parentVertex);
             createUniqueIndex(graph, label, parentVertex);
@@ -64,24 +65,18 @@ public class Indexer {
         }
     }
 
-    private void createNonUniqueIndex(Graph graph, String label, Vertex parentVertex) {
-        try {
-            databaseProvider.createIndex(graph, label, indexFields);
-            updateIndices(parentVertex, indexFields, false);
+    private void createNonUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
 
-        } catch (Exception e) {
-            logger.error("Non-unique index creation error: " + e);
-        }
+        databaseProvider.createIndex(graph, label, indexFields);
+        updateIndices(parentVertex, indexFields, false);
+
     }
 
-    private void createUniqueIndex(Graph graph, String label, Vertex parentVertex) {
-        try {
-            databaseProvider.createUniqueIndex(graph, label, indexUniqueFields);
-            updateIndices(parentVertex, indexUniqueFields, true);
+    private void createUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
 
-        } catch (Exception e) {
-            logger.error("Unique index creation error: " + e);
-        }
+        databaseProvider.createUniqueIndex(graph, label, indexUniqueFields);
+        updateIndices(parentVertex, indexUniqueFields, true);
+
     }
 
     /**

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -148,7 +148,7 @@
                       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
-         "indexFields": ["nationalIdentifier", "serialNum"],
+         "indexFields": ["serialNum","nationalIdentifier"],
          "uniqueIndexFields": ["birthDate"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -149,6 +149,6 @@
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
          "indexFields": ["nationalIdentifier"],
-         "uniqueIndexFields": []
+         "uniqueIndexFields": ["serialNum"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -148,7 +148,7 @@
                       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
-         "indexFields": ["serialNum","nationalIdentifier"],
+         "indexFields": ["nationalIdentifier"],
          "uniqueIndexFields": ["birthDate"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -149,6 +149,6 @@
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
          "indexFields": ["nationalIdentifier"],
-         "uniqueIndexFields": ["birthDate"]
+         "uniqueIndexFields": []
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -143,7 +143,9 @@
   "_osConfig": {
          "osComment": ["This section contains the OpenSABER specific configuration information", 
                       "privateFields: Optional; list of field names to be encrypted and stored in database", 
-                      "signedFields: Optional; list of field names that must be pre-signed"],                     
+                      "signedFields: Optional; list of field names that must be pre-signed",
+                      "indexFields: Optional; list of field names used for creating index",
+                      "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
          "indexFields": ["nationalIdentifier", "serialNum"],


### PR DESCRIPTION
Issue below:
1.Read API neo4jGraph throwing exception: Connection to the database was lost because someone called `interrupt()
2. Index Field property values were getting duplicating while adding new index field value.

As a part of this PR:
Introduced Indexer which  included 
+ createIndex(), setIndexFields(), setUniqueIndexFields
  updateIndices(), - createNonUniqueIndex(), - createUniqueIndex()

Introduced IndexHelper which included 2 methods
+ isIndexPresent() , getNewFields()

Added 2 methods in EntityParenter:
- asyncAddIndex() 
ensureIndexExists() : checks isIndexPresent()  and calls for asyncAddIndex()



