### PR TITLE
OS-175 Devcon identified fixes

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -14,8 +14,7 @@ import io.opensaber.registry.service.SearchService;
 import io.opensaber.registry.sink.shard.Shard;
 import io.opensaber.registry.sink.shard.ShardManager;
 import io.opensaber.registry.transform.*;
-import io.opensaber.registry.util.ReadConfigurator;
-import io.opensaber.registry.util.RecordIdentifier;
+import io.opensaber.registry.util.*;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -200,6 +199,8 @@ public class RegistryController {
 
     @RequestMapping(value = "/read", method = RequestMethod.POST)
     public ResponseEntity<Response> readEntity(@RequestHeader HttpHeaders header) {
+        boolean requireLDResponse = header.getAccept().contains(Constants.LD_JSON_MEDIA_TYPE);
+
         ResponseParams responseParams = new ResponseParams();
         Response response = new Response(Response.API_ID.READ, "OK", responseParams);
 
@@ -211,11 +212,10 @@ public class RegistryController {
 
         String acceptType = header.getAccept().iterator().next().toString();
 
-        ReadConfigurator configurator = new ReadConfigurator();
         boolean includeSignatures = (boolean) apiMessage.getRequest().getRequestMap().getOrDefault("includeSignatures",
                 false);
-        configurator.setIncludeSignatures(includeSignatures);
-        configurator.setIncludeTypeAttributes(acceptType.equals(Constants.LD_JSON_MEDIA_TYPE));
+        ReadConfigurator configurator = ReadConfiguratorFactory.getOne(includeSignatures);
+        configurator.setIncludeTypeAttributes(requireLDResponse);
 
         try {
             JsonNode resultNode = registryService.getEntity(recordId.getUuid(), configurator);

--- a/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
+++ b/java/registry/src/main/java/io/opensaber/registry/controller/RegistryController.java
@@ -133,7 +133,7 @@ public class RegistryController {
     }
 
     @RequestMapping(value = "/delete", method = RequestMethod.POST)
-    public ResponseEntity<Response> deleteEntity(@RequestHeader HttpHeaders header) {
+    public ResponseEntity<Response> deleteEntity() {
         ResponseParams responseParams = new ResponseParams();
         Response response = new Response(Response.API_ID.DELETE, "OK", responseParams);
         try {
@@ -159,7 +159,7 @@ public class RegistryController {
     }
 
     @RequestMapping(value = "/add", method = RequestMethod.POST)
-    public ResponseEntity<Response> addTP2Graph(@RequestParam(value = "id", required = false) String id,
+    public ResponseEntity<Response> addEntity(@RequestParam(value = "id", required = false) String id,
                                                 @RequestParam(value = "prop", required = false) String property) {
 
         ResponseParams responseParams = new ResponseParams();
@@ -184,7 +184,7 @@ public class RegistryController {
             String label = recordId.toString();
             resultMap.put(dbConnectionInfoMgr.getUuidPropertyName(), label);
 
-            result.put("entity", resultMap);
+            result.put(entityType, resultMap);
             response.setResult(result);
             responseParams.setStatus(Response.Status.SUCCESSFUL);
             watch.stop("RegistryController.addToExistingEntity");
@@ -199,7 +199,7 @@ public class RegistryController {
     }
 
     @RequestMapping(value = "/read", method = RequestMethod.POST)
-    public ResponseEntity<Response> greadGraph2Json(@RequestHeader HttpHeaders header) {
+    public ResponseEntity<Response> readEntity(@RequestHeader HttpHeaders header) {
         ResponseParams responseParams = new ResponseParams();
         Response response = new Response(Response.API_ID.READ, "OK", responseParams);
 
@@ -239,7 +239,7 @@ public class RegistryController {
 
     @ResponseBody
     @RequestMapping(value = "/update", method = RequestMethod.POST)
-    public ResponseEntity<Response> updateTP2Graph() {
+    public ResponseEntity<Response> updateEntity() {
         ResponseParams responseParams = new ResponseParams();
         Response response = new Response(Response.API_ID.UPDATE, "OK", responseParams);
 

--- a/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-@Component("tpGraphMain")
+@Component("registryDao")
 public class RegistryDaoImpl implements IRegistryDao {
     @Value("${database.uuidPropertyName}")
     public String uuidPropertyName;
@@ -108,7 +108,7 @@ public class RegistryDaoImpl implements IRegistryDao {
 
     /**
      * This method update the inputJsonNode related vertices in the database
-     *
+     * This works but a TODO - Re-write required
      * @param rootVertex
      * @param inputJsonNode
      */
@@ -117,7 +117,7 @@ public class RegistryDaoImpl implements IRegistryDao {
             String fieldKey = subEntityField.getKey();
             JsonNode subEntityNode = subEntityField.getValue();
             if (subEntityNode.isValueNode()) {
-                rootVertex.property(fieldKey, subEntityField.getValue().asText());
+                rootVertex.property(fieldKey, ValueType.getValue(subEntityField.getValue()));
             } else if (subEntityNode.isObject()) {
                 parseJsonObject(subEntityNode, graph, rootVertex, fieldKey, false);
             } else if (subEntityNode.isArray()) {
@@ -139,10 +139,8 @@ public class RegistryDaoImpl implements IRegistryDao {
                     arrayNodeVertex.property(RefLabelHelper.getLabel(fieldKey, uuidPropertyName), osidSet.toString());
                 } else {
                     Set<String> valueSet = new HashSet<>();
-                    subEntityNode.forEach( textElement -> {
-                        valueSet.add(textElement.asText());
-                    });
-                    rootVertex.property(fieldKey,valueSet.toString());
+                    subEntityNode.forEach(textElement -> valueSet.add(textElement.asText()));
+                    rootVertex.property(fieldKey, valueSet.toString());
                 }
 
             }

--- a/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/RegistryDaoImpl.java
@@ -64,8 +64,8 @@ public class RegistryDaoImpl implements IRegistryDao {
      * @return
      */
     public String addEntity(Graph graph, JsonNode rootNode) {
-        VertexWriter vertexWriter = new VertexWriter(uuidPropertyName, shard.getDatabaseProvider());
-        String entityId = vertexWriter.writeNodeEntity(graph, rootNode);
+        VertexWriter vertexWriter = new VertexWriter(graph, shard.getDatabaseProvider(), uuidPropertyName);
+        String entityId = vertexWriter.writeNodeEntity(rootNode);
         return entityId;
     }
 
@@ -166,10 +166,10 @@ public class RegistryDaoImpl implements IRegistryDao {
                 deleteVertices(graph, rootVertex, parentNodeLabel, null);
             }
 
-            VertexWriter vertexWriter = new VertexWriter(uuidPropertyName, shard.getDatabaseProvider());
+            VertexWriter vertexWriter = new VertexWriter(graph, shard.getDatabaseProvider(), uuidPropertyName);
 
             //Add new vertex
-            Vertex newChildVertex = vertexWriter.createVertex(graph, parentNodeLabel);
+            Vertex newChildVertex = vertexWriter.createVertex(parentNodeLabel);
             newChildVertex.property(Constants.ROOT_KEYWORD,rootVertex.property(Constants.ROOT_KEYWORD).value());
             updateProperties(elementNode, newChildVertex);
             String nodeOsidLabel = RefLabelHelper.getLabel(parentNodeLabel, uuidPropertyName);
@@ -212,7 +212,7 @@ public class RegistryDaoImpl implements IRegistryDao {
             if (value.isObject()) {
 
             } else if (value.isValueNode() && !keyType.equals("@type") && !keyType.equals(uuidPropertyName)) {
-                vertex.property(keyType, value.asText());
+                vertex.property(keyType, ValueType.getValue(value));
             }
         });
     }

--- a/java/registry/src/main/java/io/opensaber/registry/service/SignatureHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/SignatureHelper.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,50 +23,123 @@ public class SignatureHelper {
     private ObjectMapper objectMapper;
     @Value("${signature.keysURL}")
     private String signatureKeyURl;
+    @Value("${registry.context.base}")
+    private String registryContextBase;
+    @Value("${database.uuidPropertyName}")
+    public String uuidPropertyName;
 
-    /** Signs the entity and returns the entity with signed json appending
+    /**
+     * Signs the entity and returns the entity with signed json appending
+     *
+     * @param rootNode
+     * @return The new signature created
+     * @throws SignatureException.UnreachableException
+     * @throws SignatureException.CreationException
+     */
+    public JsonNode signJson(JsonNode rootNode) throws SignatureException.UnreachableException, SignatureException.CreationException {
+        String entityType = rootNode.fieldNames().next();
+
+        Map signRes = generateSignature(rootNode);
+        JsonNode newSignatureNode = convertMapToNode(entityType, signRes);
+        addSignature(rootNode, entityType, newSignatureNode);
+
+        return newSignatureNode;
+    }
+
+    /**
+     * Invokes the SignatureService to generate the signature for this entity
+     *
      * @param rootNode
      * @return
      * @throws SignatureException.UnreachableException
      * @throws SignatureException.CreationException
      */
-    public JsonNode signJson(JsonNode rootNode) throws SignatureException.UnreachableException, SignatureException.CreationException {
-        JsonNode signedRoot = rootNode;
+
+    private Map generateSignature(JsonNode rootNode) throws SignatureException.UnreachableException, SignatureException.CreationException {
         Map signReq = new HashMap<String, Object>();
         signReq.put("entity", rootNode);
         Map<String, Object> signMap = (Map<String, Object>) signatureService.sign(signReq);
 
-        String entityType = rootNode.fieldNames().next();
-        ObjectNode entityNode = (ObjectNode) rootNode.get(entityType);
-        JsonNode signNode = entityNode.get(Constants.SIGNATURES_STR);
-        signNode = mergeSign(entityType, signNode, signMap);
-        entityNode.set(Constants.SIGNATURES_STR,signNode);
-        return signedRoot;
+        return signMap;
     }
 
-    /** Merges sign data to entity json
-     * @param entityType
-     * @param signNode
-     * @param signMap
+    /**
+     * Converts map to signature node
+     *
+     * @param entityType Entity name for which the signature node needs to be generated
+     * @param signMap    The response got from signature service
+     * @return
      */
-    private ArrayNode mergeSign(String entityType, JsonNode signNode, Map<String, Object> signMap) {
-        ArrayNode parentSignNode;
-        if(signNode != null && signNode.isArray()){
-            parentSignNode = (ArrayNode) signNode;
-        } else {
-            parentSignNode = JsonNodeFactory.instance.arrayNode();
-        }
+    private JsonNode convertMapToNode(String entityType, Map<String, Object> signMap) {
         Map<String, Object> entitySignMap = new HashMap<>();
         entitySignMap.put(Constants.SIGN_SIGNATURE_VALUE, signMap.get(Constants.SIGN_SIGNATURE_VALUE));
         entitySignMap.put(Constants.SIGN_CREATOR, signatureKeyURl + signMap.get("keyId"));
-        entitySignMap.put(Constants.SIGNATURE_FOR, entityType);
+        entitySignMap.put(Constants.SIGNATURE_FOR, registryContextBase + entityType);
         entitySignMap.put(Constants.TYPE_STR_JSON_LD, "RSASignature2018");
-        entitySignMap.put(Constants.SIGN_CREATED_TIMESTAMP, "");
+        entitySignMap.put(Constants.SIGN_CREATED_TIMESTAMP, Instant.now().toString());
         entitySignMap.put(Constants.SIGN_NONCE, "");
         JsonNode entitySignNode = objectMapper.convertValue(entitySignMap, JsonNode.class);
-        parentSignNode.add(entitySignNode);
-        return parentSignNode;
+        return entitySignNode;
     }
 
+    /**
+     * Merges sign data to entity json
+     *
+     * @param entityNode
+     * @param toAdd
+     */
+    private void addSignature(JsonNode entityNode, String entityType, JsonNode toAdd) {
+        ArrayNode existingSignatures = (ArrayNode) entityNode.get(entityType).get(Constants.SIGNATURES_STR);
+        if (existingSignatures == null) {
+            existingSignatures = JsonNodeFactory.instance.arrayNode();
+        }
+        existingSignatures.add(toAdd);
 
+        ((ObjectNode) entityNode).set(Constants.SIGNATURES_STR, existingSignatures);
+    }
+
+    /**
+     * Gets the signature for the supplied itemName
+     *
+     * @param itemName
+     * @param signaturesArr
+     * @return
+     */
+    public JsonNode getItemSignature(String itemName, JsonNode signaturesArr) {
+        JsonNode entitySignature = null;
+        if (null != signaturesArr && signaturesArr.isArray()) {
+            for (JsonNode signatureItem : signaturesArr) {
+                if (signatureItem.get(Constants.SIGNATURE_FOR).textValue().contains(itemName)) {
+                    entitySignature = signatureItem;
+                }
+            }
+        }
+        return entitySignature;
+    }
+
+    /**
+     * Removes the entity signature from the node
+     *
+     * @param entityNodeType
+     * @param node
+     */
+    public String removeEntitySignature(String entityNodeType, ObjectNode node) {
+        String entitySignatureUUID = "";
+        ArrayNode signatureArr = (ArrayNode) node.get(entityNodeType).get(Constants.SIGNATURES_STR);
+        if (null != signatureArr && !signatureArr.isNull()) {
+            int entitySignatureIdx = -1;
+            for (int itr = 0; itr < signatureArr.size(); itr++) {
+                JsonNode signature = signatureArr.get(itr);
+                if (signature.get(Constants.SIGNATURE_FOR).toString().contains(entityNodeType)) {
+                    entitySignatureIdx = itr;
+                    entitySignatureUUID = signature.get(uuidPropertyName).textValue();
+                    break;
+                }
+            }
+            if (entitySignatureIdx != -1) {
+                signatureArr.remove(entitySignatureIdx);
+            }
+        }
+        return entitySignatureUUID;
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/service/SignatureHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/SignatureHelper.java
@@ -63,6 +63,10 @@ public class SignatureHelper {
         return signMap;
     }
 
+    public String getEntitySignaturePrefix() {
+        return registryContextBase;
+    }
+
     /**
      * Converts map to signature node
      *

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/RegistryServiceImpl.java
@@ -92,9 +92,6 @@ public class RegistryServiceImpl implements RegistryService {
     private Shard shard;
 
     @Autowired
-    RegistryDaoImpl tpGraphMain;
-
-    @Autowired
     DBConnectionInfoMgr dbConnectionInfoMgr;
 
     @Autowired
@@ -149,7 +146,7 @@ public class RegistryServiceImpl implements RegistryService {
                 Vertex vertex = vertexItr.next();
                 if (!(vertex.property(Constants.STATUS_KEYWORD).isPresent()
                         && vertex.property(Constants.STATUS_KEYWORD).value().equals(Constants.STATUS_INACTIVE))) {
-                    tpGraphMain.deleteEntity(vertex);
+                    registryDao.deleteEntity(vertex);
                     tx.commit();
                 } else {
                     // throw exception node already deleted
@@ -181,7 +178,7 @@ public class RegistryServiceImpl implements RegistryService {
             try (OSGraph osGraph = dbProvider.getOSGraph()) {
                 Graph graph = osGraph.getGraphStore();
                 Transaction tx = dbProvider.startTransaction(graph);
-                entityId = tpGraphMain.addEntity(graph, rootNode);
+                entityId = registryDao.addEntity(graph, rootNode);
                 shard.getDatabaseProvider().commitTransaction(graph, tx);
                 dbProvider.commitTransaction(graph, tx);
 
@@ -272,7 +269,7 @@ public class RegistryServiceImpl implements RegistryService {
         try (OSGraph osGraph = dbProvider.getOSGraph()) {
             Graph graph = osGraph.getGraphStore();
             Transaction tx = dbProvider.startTransaction(graph);
-            JsonNode result = tpGraphMain.getEntity(graph, id, configurator);
+            JsonNode result = registryDao.getEntity(graph, id, configurator);
             shard.getDatabaseProvider().commitTransaction(graph, tx);
             dbProvider.commitTransaction(graph, tx);
             return result;
@@ -325,7 +322,7 @@ public class RegistryServiceImpl implements RegistryService {
                 // TO-DO validation is failing
                 // boolean isValidate =
                 // iValidate.validate("Teacher",entityNode.toString());
-                tpGraphMain.updateVertex(graph, inputNodeVertex, childElementNode);
+                registryDao.updateVertex(graph, inputNodeVertex, childElementNode);
                 // sign the entitynode
                 if (signatureEnabled) {
                     signatureHelper.signJson(entityNode);
@@ -341,7 +338,7 @@ public class RegistryServiceImpl implements RegistryService {
                         Vertex signVertex = sign.next();
                         // Other signatures are not updated, only the entity
                         // level signature.
-                        tpGraphMain.updateVertex(graph, signVertex, signNode);
+                        registryDao.updateVertex(graph, signVertex, signNode);
                     }
                 }
                 databaseProvider.commitTransaction(graph, tx);
@@ -356,7 +353,7 @@ public class RegistryServiceImpl implements RegistryService {
                 // TO-DO validation is failing
                 // boolean isValidate =
                 // iValidate.validate("Teacher",entityNode.toString());
-                tpGraphMain.updateVertex(graph, inputNodeVertex, childElementNode);
+                registryDao.updateVertex(graph, inputNodeVertex, childElementNode);
 
                 // sign the entitynode
                 if (signatureEnabled) {
@@ -369,7 +366,7 @@ public class RegistryServiceImpl implements RegistryService {
                     while (null != vertices && vertices.hasNext()) {
                         Vertex signVertex = vertices.next();
                         if (signVertex.property(Constants.SIGNATURE_FOR).value().equals(entityNodeType)) {
-                            tpGraphMain.updateVertex(graph, signVertex, signNode);
+                            registryDao.updateVertex(graph, signVertex, signNode);
                         }
                     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -71,8 +71,8 @@ public class EntityParenter {
                         defintionNames.forEach(defintionName -> {
                             String parentLabel = ParentLabelGenerator.getLabel(defintionName);
                             parentLabels.add(parentLabel);
-                            VertexWriter vertexWriter = new VertexWriter(uuidPropertyName, dbProvider);
-                            Vertex v = vertexWriter.ensureParentVertex(graph, parentLabel);
+                            VertexWriter vertexWriter = new VertexWriter(graph, dbProvider, uuidPropertyName);
+                            Vertex v = vertexWriter.ensureParentVertex(parentLabel);
 
                             ShardParentInfo shardParentInfo = new ShardParentInfo(defintionName, v);
                             shardParentInfo.setUuid(v.id().toString());

--- a/java/registry/src/main/java/io/opensaber/registry/util/ReadConfigurator.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ReadConfigurator.java
@@ -28,6 +28,18 @@ public class ReadConfigurator {
      */
     private boolean includeSignatures = false;
 
+    /**
+     * Whether or not to include identifiers
+     * True by default
+     */
+    private boolean includeIdentifiers = true;
+
+    /**
+     * Whether or not to include root identifiers
+     * False, by default
+     */
+    private boolean includeRootIdentifiers = false;
+
     public boolean isIncludeTypeAttributes() {
         return includeTypeAttributes;
     }
@@ -58,5 +70,21 @@ public class ReadConfigurator {
 
     public void setDepth(int depth) {
         this.depth = depth;
+    }
+
+    public boolean isIncludeIdentifiers() {
+        return includeIdentifiers;
+    }
+
+    public void setIncludeIdentifiers(boolean includeIdentifiers) {
+        this.includeIdentifiers = includeIdentifiers;
+    }
+
+    public boolean isIncludeRootIdentifiers() {
+        return includeRootIdentifiers;
+    }
+
+    public void setIncludeRootIdentifiers(boolean includeRootIdentifiers) {
+        this.includeRootIdentifiers = includeRootIdentifiers;
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/ReadConfiguratorFactory.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ReadConfiguratorFactory.java
@@ -1,4 +1,43 @@
 package io.opensaber.registry.util;
 
 public class ReadConfiguratorFactory {
+    public static ReadConfigurator getDefault() {
+        ReadConfigurator configurator = new ReadConfigurator();
+        configurator.setIncludeSignatures(false);
+        configurator.setIncludeTypeAttributes(false);
+        return configurator;
+    }
+
+    public static ReadConfigurator getWithSignatures() {
+        ReadConfigurator configurator = new ReadConfigurator();
+        configurator.setIncludeSignatures(true);
+        configurator.setIncludeTypeAttributes(false);
+        return configurator;
+    }
+
+    public static ReadConfigurator getOne(boolean withSignatures) {
+        if (withSignatures) {
+            return getWithSignatures();
+        } else {
+            return  getDefault();
+        }
+    }
+
+    public static ReadConfigurator getForUpdateValidation() {
+        ReadConfigurator configurator = new ReadConfigurator();
+        // For update, there could be signatures required.
+        configurator.setIncludeSignatures(true);
+
+        // Get rid of type attributes, which would fail validation
+        configurator.setIncludeTypeAttributes(false);
+
+        // Load uuidPropertyNames too and remove before validation
+        configurator.setIncludeIdentifiers(true);
+
+        // We want to know if the passed in value is child or not
+        configurator.setIncludeRootIdentifiers(true);
+
+        return configurator;
+    }
+
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/ReadConfiguratorFactory.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ReadConfiguratorFactory.java
@@ -1,0 +1,4 @@
+package io.opensaber.registry.util;
+
+public class ReadConfiguratorFactory {
+}

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -21,17 +21,6 @@
         </encoder>
     </appender>
 
-    <!--
-    <appender name="PERF_FILE_OUT" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/performance_instrumentation.log</file>
-        <append>true</append>
-        <immediateFlush>true</immediateFlush>
-        <encoder>
-            # Pattern of log message for file appender
-             <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
-        </encoder>
-    </appender>
-    -->
 
     <appender name="RegistryAuditAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/registry_neo4j.log</file>
@@ -65,17 +54,6 @@
         </rollingPolicy>
     </appender>
 
-    <!--
-    <appender name="Perf4JConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>debug</level>
-        </filter>
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%date %-5level %logger{36} %msg%n
-            </pattern>
-        </layout>
-    </appender>
-    -->
 
     <appender name="CoalescingStatistics" class="org.perf4j.logback.AsyncCoalescingStatisticsAppender">
         <param name="TimeSlice" value="600000"/>
@@ -94,16 +72,15 @@
         <!-- <appender-ref ref="Perf4JConsoleAppender"/> -->
     </logger>
 
-    <logger name="io.opensaber.validators.shex.shaclex" level="ERROR"/>
     <logger name="es.weso" level="ERROR"/>
-    <logger name="io.opensaber.utils.converters" level="ERROR"/>
-    <logger name="io.opensaber.registry.dao.impl.RegistryDaoImpl" level="ERROR"/>
     <logger name="org.springframework" level="ERROR"/>
-    <!--
-    <logger name="PERFORMANCE_INSTRUMENTATION" level="TRACE" additivity="false">
-        <appender-ref ref="PERF_FILE_OUT"/>
-    </logger>
-    -->
+
+    <!-- OpenSABER specific loggers. Turn these to INFO in production -->
+    <logger name="io.opensaber.registry.service" level="DEBUG"/>
+    <logger name="com.steelbridgelabs.oss.neo4j.structure.Neo4JSession" level="DEBUG"/>
+    <logger name="io.opensaber.registry.dao.RegistryDaoImpl" level="DEBUG"/>
+    <logger name="com.mchange.v2.c3p0.impl.NewProxyPreparedStatement" level="DEBUG"/>
+
     <logger name="GraphEventLogger" level="DEBUG" additivity="FALSE">
         <appender-ref ref="RegistryAuditAppender"/>
     </logger>


### PR DESCRIPTION
- When adding an entity, let the response be wrapped under entityType, like Teacher/Person/Vehicle. Currently it is just returned as ‘entity’.
- The signatureFor for the entity type must include the registry context base, can’t just be the entity name.
- The signature created timestamp was not getting set and that’s added now.
- tpGraphMain is renamed to registryDao
- VertexReader, VertexWriter and SignatureHelper has underwent minor refactoring to trim parameters and improve testability.
- ReadConfigurator related changes were probably not needed in this, but I was planning to push the update refactoring too in this release. This refactoring couldn’t be completed but throwing some good stuff early on here itself.
- Logback is now set to print debug sql-postgres and neo4j queries.

**Testing**
1. Added a teacher entity and saw the response contained "Teacher"
2. Hit the READ api and found the signatureFor field for the Teacher entity contains http://localhost:8080 prefix. 
3. The created timestamp also was not empty
4. Hit update with changing the "daysOfNonTeachingAssignments": 10 (this was an integer). Hit READ just after update and observed the integer returned back (previously was returned as string).