### PR TITLE
Os 181 :  Adding unique constraints to Neo4j database provider

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
@@ -69,49 +69,23 @@ public class VertexWriter {
 
         return vertex;
     }
-
+    
     /**
-     * Updates INDEX_FIELDS(single, composite) and UNIQUE_INDEX_FIELDS property of parent vertex
+     * Updates index fields property of parent vertex for a given propertyName
      * 
-     * @param parentlabel
+     * @param parentVertex
+     * @param propertyName
      * @param indexFields
-     * @param uniqueIndexFields
      */
-    public void updateParentIndexProperty(String parentlabel, List<String> indexFields, List<String> uniqueIndexFields) { 
-
-        //Non-unique
+    public void updateParentIndexProperty(Vertex parentVertex, String propertyName, List<String> indexFields){
         if (indexFields.size() > 0) {
-            replaceVertexProperty(parentlabel, indexFields, false);
-        }
-        //unique
-        if(uniqueIndexFields.size() > 0){
-            replaceVertexProperty(parentlabel, uniqueIndexFields, true);
-  
-        }
-    }
-
-    /**
-     * Replace the INDEX_FIELDS and UNIQUE_INDEX_FIELDS of parent vertex
-     * 
-     * @param parentlabel
-     * @param indexFields
-     * @param isUnique
-     */
-    private void replaceVertexProperty(String parentlabel, List<String> indexFields, boolean isUnique){
-        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
-        StringBuilder properties = new StringBuilder(String.join(",", indexFields));        
-        P<String> lblPredicate = P.eq(parentlabel);
-        GraphTraversalSource gtRootTraversal = graph.traversal().clone();
-        Iterator<Vertex> iterVertex = gtRootTraversal.V().hasLabel(lblPredicate);
-        if (iterVertex.hasNext()) {
-            Vertex pVertex = iterVertex.next();
-            pVertex.property(propertyName, properties.toString());
+            StringBuilder properties = new StringBuilder(String.join(",", indexFields));        
+            Vertex v = graph.vertices(parentVertex.id()).next();
+            v.property(propertyName, properties.toString());
             logger.info("parent vertex property {}:{}", propertyName, properties);
-        }
-        
+
+        }            
     }
-
-
 
     /**
      * Writes an array into the database. For each array item, if it is an

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
@@ -80,8 +80,7 @@ public class VertexWriter {
     public void updateParentIndexProperty(Vertex parentVertex, String propertyName, List<String> indexFields){
         if (indexFields.size() > 0) {
             StringBuilder properties = new StringBuilder(String.join(",", indexFields));        
-            Vertex v = graph.vertices(parentVertex.id()).next();
-            v.property(propertyName, properties.toString());
+            parentVertex.property(propertyName, properties.toString());
             logger.info("parent vertex property {}:{}", propertyName, properties);
 
         }            

--- a/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/VertexWriter.java
@@ -71,6 +71,49 @@ public class VertexWriter {
     }
 
     /**
+     * Updates INDEX_FIELDS(single, composite) and UNIQUE_INDEX_FIELDS property of parent vertex
+     * 
+     * @param parentlabel
+     * @param indexFields
+     * @param uniqueIndexFields
+     */
+    public void updateParentIndexProperty(String parentlabel, List<String> indexFields, List<String> uniqueIndexFields) { 
+
+        //Non-unique
+        if (indexFields.size() > 0) {
+            replaceVertexProperty(parentlabel, indexFields, false);
+        }
+        //unique
+        if(uniqueIndexFields.size() > 0){
+            replaceVertexProperty(parentlabel, uniqueIndexFields, true);
+  
+        }
+    }
+
+    /**
+     * Replace the INDEX_FIELDS and UNIQUE_INDEX_FIELDS of parent vertex
+     * 
+     * @param parentlabel
+     * @param indexFields
+     * @param isUnique
+     */
+    private void replaceVertexProperty(String parentlabel, List<String> indexFields, boolean isUnique){
+        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
+        StringBuilder properties = new StringBuilder(String.join(",", indexFields));        
+        P<String> lblPredicate = P.eq(parentlabel);
+        GraphTraversalSource gtRootTraversal = graph.traversal().clone();
+        Iterator<Vertex> iterVertex = gtRootTraversal.V().hasLabel(lblPredicate);
+        if (iterVertex.hasNext()) {
+            Vertex pVertex = iterVertex.next();
+            pVertex.property(propertyName, properties.toString());
+            logger.info("parent vertex property {}:{}", propertyName, properties);
+        }
+        
+    }
+
+
+
+    /**
      * Writes an array into the database. For each array item, if it is an
      * object creates/populates a new vertex/table and stores the reference
      *

--- a/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/DatabaseProvider.java
@@ -161,6 +161,12 @@ public abstract class DatabaseProvider {
     public void createUniqueIndex(Graph graph, String label, List<String> propertyNames){
         //Does nothing, suppose to be overridden by extended classes.
     }
+    /**
+     * Creates composite index
+     */
+    public void createCompositeIndex(Graph graph, String label, List<String> propertyNames){
+        //Does nothing, suppose to be overridden by extended classes.
+    }
         
     public Constants.GraphDatabaseProvider getProvider() {
         return this.provider;

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -115,14 +115,25 @@ public class Neo4jGraphProvider extends DatabaseProvider {
     @Override
     public void createCompositeIndex(Graph graph, String label, List<String> propertyNames){
         Neo4JGraph neo4jGraph = (Neo4JGraph) graph;
-        String properties = "";
-        for (String propertyName : propertyNames) {
-            properties = properties.isEmpty() ? propertyName : (properties + "," + propertyName);
-            logger.info("composite key properties values "+properties);
-        }       
+        StringBuilder properties = new StringBuilder(String.join(",", propertyNames));
+        logger.info("composite key properties values "+properties);
+        
         Objects.requireNonNull(label, "label cannot be null");
-        Objects.requireNonNull(properties, "propertyName cannot be null");
+        Objects.requireNonNull(properties, "properties cannot be null");
         neo4jGraph.execute(new Statement("CREATE INDEX ON :`" + label + "`(" + properties + ")"));
+
+    }
+    
+    @Override
+    public void createUniqueIndex(Graph graph, String label, List<String> propertyNames) {
+        Neo4JGraph neo4jGraph = (Neo4JGraph) graph;
+        for (String propertyName : propertyNames) {
+            Objects.requireNonNull(label, "label cannot be null");
+            Objects.requireNonNull(propertyName, "propertyName cannot be null");
+            neo4jGraph.execute(new Statement("CREATE CONSTRAINT ON (n:" + label + ") ASSERT n." + propertyName + " IS UNIQUE"));
+            logger.info("Neo4jGraph unique index created for " + label);
+
+        }       
 
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/Neo4jGraphProvider.java
@@ -7,6 +7,7 @@ import com.steelbridgelabs.oss.neo4j.structure.Neo4JVertex;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.model.DBConnectionInfo;
 import java.util.List;
+import java.util.Objects;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -16,6 +17,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,13 +105,24 @@ public class Neo4jGraphProvider extends DatabaseProvider {
 
     @Override
     public void createIndex(Graph graph,String label, List<String> propertyNames) {
-
-        Neo4JGraph neo4jGraph = (Neo4JGraph) graph;
-        
+        Neo4JGraph neo4jGraph = (Neo4JGraph) graph;       
         for (String propertyName : propertyNames) {
             neo4jGraph.createIndex(label, propertyName);
             logger.info("Neo4jGraph index created for " + label);
-        }
-        
+        }        
+    }
+    
+    @Override
+    public void createCompositeIndex(Graph graph, String label, List<String> propertyNames){
+        Neo4JGraph neo4jGraph = (Neo4JGraph) graph;
+        String properties = "";
+        for (String propertyName : propertyNames) {
+            properties = properties.isEmpty() ? propertyName : (properties + "," + propertyName);
+            logger.info("composite key properties values "+properties);
+        }       
+        Objects.requireNonNull(label, "label cannot be null");
+        Objects.requireNonNull(properties, "propertyName cannot be null");
+        neo4jGraph.execute(new Statement("CREATE INDEX ON :`" + label + "`(" + properties + ")"));
+
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/sink/OSGraph.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/OSGraph.java
@@ -14,6 +14,9 @@ public class OSGraph implements AutoCloseable {
     }
 
     public void close() throws Exception {
+        if (graph != null && graph.tx().isOpen()) {
+            graph.tx().close();
+        }
         if (closeRequired) {
             graph.close();
         } else {

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -67,7 +67,7 @@ public class SqlgProvider extends DatabaseProvider {
 
     @Override
     public void createCompositeIndex(Graph graph, String label, List<String> propertyNames) {
-        createCompositeIndexByIndexType(graph, IndexType.NON_UNIQUE, label, propertyNames);
+        ensureCompositeIndex(graph, label, propertyNames);
     }
 
     @Override
@@ -92,20 +92,19 @@ public class SqlgProvider extends DatabaseProvider {
         }
     }
     /**
-     * create composite index for a given label for non-unique index type
+     * ensures composite index for a given label for non-unique index type
      * @param graph
-     * @param indexType
      * @param label
      * @param propertyNames
      */
-    private void createCompositeIndexByIndexType(Graph graph, IndexType indexType, String label, List<String> propertyNames) {
+    private void ensureCompositeIndex(Graph graph, String label, List<String> propertyNames) {
         VertexLabel vertexLabel = getVertex(label);
         List<PropertyColumn> properties = new ArrayList<>();
 
         for (String propertyName : propertyNames) {
             properties.add(vertexLabel.getProperty(propertyName).get());
         }
-        ensureIndex(vertexLabel, indexType, properties);
+        ensureIndex(vertexLabel, IndexType.NON_UNIQUE, properties);
     }
     /**
      * 

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -107,11 +107,20 @@ public class SqlgProvider extends DatabaseProvider {
         }
         ensureIndex(vertexLabel, IndexType.NON_UNIQUE, properties);
     }
-
+    /**
+     * 
+     * @param label
+     * @return
+     */
     private VertexLabel getVertexLabel(String label) {
         return ((SqlgGraph) graph).getTopology().ensureVertexLabelExist(label);
     }
-
+    /**
+     * ensure index for a given label for non-unique index type
+     * @param vertexLabel
+     * @param indexType
+     * @param properties
+     */
     private void ensureIndex(VertexLabel vertexLabel, IndexType indexType, List<PropertyColumn> properties) {
         Index index = vertexLabel.ensureIndexExists(indexType, properties);
         logger.info(indexType + "index created for " + vertexLabel.getLabel() + " - " + index.getName());

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -67,7 +67,7 @@ public class SqlgProvider extends DatabaseProvider {
 
     @Override
     public void createCompositeIndex(Graph graph, String label, List<String> propertyNames) {
-        createCompositeIndexByIndexType(graph, label, propertyNames);
+        createCompositeIndexByIndexType(graph, IndexType.NON_UNIQUE, label, propertyNames);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class SqlgProvider extends DatabaseProvider {
      * @param propertyNames
      */
     private void createIndexByIndexType(Graph graph, IndexType indexType, String label, List<String> propertyNames) {
-        VertexLabel vertexLabel = getVertexLabel(label);
+        VertexLabel vertexLabel = getVertex(label);
         for (String propertyName : propertyNames) {
             List<PropertyColumn> properties = new ArrayList<>();
             properties.add(vertexLabel.getProperty(propertyName).get());
@@ -98,21 +98,21 @@ public class SqlgProvider extends DatabaseProvider {
      * @param label
      * @param propertyNames
      */
-    private void createCompositeIndexByIndexType(Graph graph, String label, List<String> propertyNames) {
-        VertexLabel vertexLabel = getVertexLabel(label);
+    private void createCompositeIndexByIndexType(Graph graph, IndexType indexType, String label, List<String> propertyNames) {
+        VertexLabel vertexLabel = getVertex(label);
         List<PropertyColumn> properties = new ArrayList<>();
 
         for (String propertyName : propertyNames) {
             properties.add(vertexLabel.getProperty(propertyName).get());
         }
-        ensureIndex(vertexLabel, IndexType.NON_UNIQUE, properties);
+        ensureIndex(vertexLabel, indexType, properties);
     }
     /**
      * 
      * @param label
      * @return
      */
-    private VertexLabel getVertexLabel(String label) {
+    private VertexLabel getVertex(String label) {
         return ((SqlgGraph) graph).getTopology().ensureVertexLabelExist(label);
     }
     /**

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -84,7 +84,7 @@ public class SqlgProvider extends DatabaseProvider {
      * @param propertyNames
      */
     private void createIndexByIndexType(Graph graph, IndexType indexType, String label, List<String> propertyNames) {
-        VertexLabel vertexLabel = getVertex(label);
+        VertexLabel vertexLabel = getVertex(graph, label);
         for (String propertyName : propertyNames) {
             List<PropertyColumn> properties = new ArrayList<>();
             properties.add(vertexLabel.getProperty(propertyName).get());
@@ -98,7 +98,7 @@ public class SqlgProvider extends DatabaseProvider {
      * @param propertyNames
      */
     private void ensureCompositeIndex(Graph graph, String label, List<String> propertyNames) {
-        VertexLabel vertexLabel = getVertex(label);
+        VertexLabel vertexLabel = getVertex(graph, label);
         List<PropertyColumn> properties = new ArrayList<>();
 
         for (String propertyName : propertyNames) {
@@ -111,7 +111,7 @@ public class SqlgProvider extends DatabaseProvider {
      * @param label
      * @return
      */
-    private VertexLabel getVertex(String label) {
+    private VertexLabel getVertex(Graph graph, String label) {
         return ((SqlgGraph) graph).getTopology().ensureVertexLabelExist(label);
     }
     /**

--- a/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
+++ b/java/registry/src/main/java/io/opensaber/registry/sink/SqlgProvider.java
@@ -107,7 +107,8 @@ public class SqlgProvider extends DatabaseProvider {
         ensureIndex(vertexLabel, IndexType.NON_UNIQUE, properties);
     }
     /**
-     * 
+     * Ensures that the vertex table exist in the db.
+     * @param graph
      * @param label
      * @return
      */

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -282,8 +282,10 @@ public class EntityParenter {
             try (Transaction tx = dbProvider.startTransaction(graph)) {
 
                 VertexWriter vertexWriter = new VertexWriter(graph, dbProvider, uuidPropertyName);
-                vertexWriter.updateParentIndexProperty(parentVertex, Constants.INDEX_FIELDS, indexFields);
-                vertexWriter.updateParentIndexProperty(parentVertex, Constants.UNIQUE_INDEX_FIELDS, indexUniqueFields);
+                Vertex v = graph.vertices(parentVertex.id()).next();
+                
+                vertexWriter.updateParentIndexProperty(v, Constants.INDEX_FIELDS, indexFields);
+                vertexWriter.updateParentIndexProperty(v, Constants.UNIQUE_INDEX_FIELDS, indexUniqueFields);
                 dbProvider.commitTransaction(graph, tx);
             }
         }

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -28,10 +28,10 @@ public class EntityParenter {
 
     @Autowired
     private IndexHelper indexHelper;
-    
+
     @Value("${database.uuidPropertyName}")
     public String uuidPropertyName;
-    
+
     @Autowired
     private DBProviderFactory dbProviderFactory;
 
@@ -54,35 +54,37 @@ public class EntityParenter {
         defintionNames = this.definitionsManager.getAllKnownDefinitions();
         dbConnectionInfoList = this.dbConnectionInfoMgr.getConnectionInfo();
     }
+
     /**
-     * Loads all the definitions for each shard 
+     * Loads all the definitions for each shard
      */
     public void loadDefinitionIndex() {
         Map<String, Boolean> indexMap = new ConcurrentHashMap<String, Boolean>();
 
-        for (Map.Entry<String, ShardParentInfoList> entry : shardParentMap.entrySet()){
-          String shardId = entry.getKey();
-          ShardParentInfoList shardParentInfoList = entry.getValue();
-          shardParentInfoList.getParentInfos().forEach(shardParentInfo->{
-              Definition definition = definitionsManager.getDefinition(shardParentInfo.getName());
-              Vertex parentVertex = shardParentInfo.getVertex();
-              List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
-              List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
-              
-              List<String> compositeIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
-              List<String> singleIndexFields = IndexHelper.getSingleIndexFields(indexFields);
+        for (Map.Entry<String, ShardParentInfoList> entry : shardParentMap.entrySet()) {
+            String shardId = entry.getKey();
+            ShardParentInfoList shardParentInfoList = entry.getValue();
+            shardParentInfoList.getParentInfos().forEach(shardParentInfo -> {
+                Definition definition = definitionsManager.getDefinition(shardParentInfo.getName());
+                Vertex parentVertex = shardParentInfo.getVertex();
+                List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
+                List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
 
-              int nNewIndices = indexHelper.getNewFields(parentVertex, singleIndexFields, false).size();
-              int nNewUniqIndices = indexHelper.getNewFields(parentVertex, indexUniqueFields, true).size();
-              int nNewCompIndices = indexHelper.getNewFields(parentVertex, compositeIndexFields, false).size();
-            
-              boolean indexingComplete = (nNewIndices == 0 && nNewUniqIndices == 0 && nNewCompIndices == 0);
-              indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), indexingComplete);
-              logger.info("On loadDefinitionIndex for Shard:"+ shardId + " definition: {} updated index to {} ", definition.getTitle(), indexingComplete);
-              
-          });
-          
-        }        
+                List<String> compositeIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
+                List<String> singleIndexFields = IndexHelper.getSingleIndexFields(indexFields);
+
+                int nNewIndices = indexHelper.getNewFields(parentVertex, singleIndexFields, false).size();
+                int nNewUniqIndices = indexHelper.getNewFields(parentVertex, indexUniqueFields, true).size();
+                int nNewCompIndices = indexHelper.getNewFields(parentVertex, compositeIndexFields, false).size();
+
+                boolean indexingComplete = (nNewIndices == 0 && nNewUniqIndices == 0 && nNewCompIndices == 0);
+                indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), indexingComplete);
+                logger.info("On loadDefinitionIndex for Shard:" + shardId + " definition: {} updated index to {} ",
+                        definition.getTitle(), indexingComplete);
+
+            });
+
+        }
         indexHelper.setDefinitionIndexMap(indexMap);
     }
 
@@ -96,7 +98,8 @@ public class EntityParenter {
         Optional<String> result;
 
         dbConnectionInfoList.forEach(dbConnectionInfo -> {
-            logger.info("Starting to parents for {} definitions in shard {}", defintionNames.size(), dbConnectionInfo.getShardId());
+            logger.info("Starting to parents for {} definitions in shard {}", defintionNames.size(),
+                    dbConnectionInfo.getShardId());
             DatabaseProvider dbProvider = dbProviderFactory.getInstance(dbConnectionInfo);
             try {
                 try (OSGraph osGraph = dbProvider.getOSGraph()) {
@@ -124,7 +127,8 @@ public class EntityParenter {
 
                         dbProvider.commitTransaction(graph, tx);
                     }
-                    logger.info("Ensured parents for {} definitions in shard {}", defintionNames.size(), dbConnectionInfo.getShardId());
+                    logger.info("Ensured parents for {} definitions in shard {}", defintionNames.size(),
+                            dbConnectionInfo.getShardId());
                 }
             } catch (Exception e) {
                 logger.error("Can't ensure parents for definitions " + e);
@@ -169,41 +173,26 @@ public class EntityParenter {
         }
         return vertex;
     }
+
     /**
-     * Indices gets added 
+     * Indices gets added
      */
-    public void ensureIndexExists(){        
+    public void ensureIndexExists() {
         dbConnectionInfoList.forEach(dbConnectionInfo -> {
             DatabaseProvider dbProvider = dbProviderFactory.getInstance(dbConnectionInfo);
-            try {
-                try (OSGraph osGraph = dbProvider.getOSGraph()) {
-                    Graph graph = osGraph.getGraphStore();
-                    try (Transaction tx = dbProvider.startTransaction(graph)) {
-                        List<String> parentLabels = new ArrayList<>();
-                        defintionNames.forEach(defintionName -> {
-                            
-                            String parentLabel = ParentLabelGenerator.getLabel(defintionName);
-                            parentLabels.add(parentLabel);
-                            VertexWriter vertexWriter = new VertexWriter(graph, dbProvider, uuidPropertyName);
-                            Vertex v = vertexWriter.ensureParentVertex(parentLabel);
 
-                            //adding index to shard
-                            Definition definition = definitionsManager.getDefinition(defintionName);
-                            ensureIndexExists(dbProvider, v, definition, dbConnectionInfo.getShardId());
-                        });
-                        dbProvider.commitTransaction(graph, tx);
-                    }
-                }
-                
-            } catch (Exception e) {
-                logger.error("ensureIndex error: {}", e);
+            for (Map.Entry<String, ShardParentInfoList> entry : shardParentMap.entrySet()) {
+                List<ShardParentInfo> shardParentInfoList = entry.getValue().getParentInfos();
+                shardParentInfoList.forEach(shardParentInfo -> {
+                    Definition definition = definitionsManager.getDefinition(shardParentInfo.getName());
+                    Vertex v = shardParentInfo.getVertex();
+                    ensureIndexExists(dbProvider, v, definition, dbConnectionInfo.getShardId());
+
+                });
             }
         });
-
-        
- 
     }
-    
+
     /**
      * Ensures index for a vertex exists Unique index and non-unique index is
      * supported
@@ -212,60 +201,68 @@ public class EntityParenter {
      * @param parentVertex
      * @param definition
      */
-    public  void ensureIndexExists(DatabaseProvider dbProvider, Vertex parentVertex, Definition definition, String shardId) {
-        try{
-            if(!indexHelper.isIndexPresent(definition, shardId)){
-                logger.info("Adding index to shard: {} for definition: {}", shardId, definition.getTitle() );
-                asyncAddIndex(dbProvider,shardId, parentVertex, definition);
+    public void ensureIndexExists(DatabaseProvider dbProvider, Vertex parentVertex, Definition definition,
+            String shardId) {
+        try {
+            if (!indexHelper.isIndexPresent(definition, shardId)) {
+                logger.info("Adding index to shard: {} for definition: {}", shardId, definition.getTitle());
+                asyncAddIndex(dbProvider, shardId, parentVertex, definition);
             }
-        }catch(Exception e){
-            logger.error("ensureIndexExists: Can't create index on table {} for shardId: {} ", definition.getTitle(), shardId);
+        } catch (Exception e) {
+            logger.error("ensureIndexExists: Can't create index on table {} for shardId: {} ", definition.getTitle(),
+                    shardId);
         }
     }
-    
+
     /**
      * Adds indices to the given label(vertex/table) asynchronously
+     * 
      * @param dbProvider
      * @param parentVertex
      * @param definition
      */
-    private void asyncAddIndex(DatabaseProvider dbProvider, String shardId, Vertex parentVertex, Definition definition) {
+
+    private void asyncAddIndex(DatabaseProvider dbProvider, String shardId, Vertex parentVertex,
+            Definition definition) {
         new Thread(() -> {
-            if(parentVertex != null && definition != null){
+            if (parentVertex != null && definition != null) {
                 boolean status = false;
                 try {
-                    OSGraph osGraph = dbProvider.getOSGraph();
-                    Graph graph = osGraph.getGraphStore();
-                    Transaction tx = dbProvider.startTransaction(graph);           
-                    
-                        
-                        List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
-                        if(!indexFields.contains(uuidPropertyName)){
-                            // adds default field (uuid)
-                            indexFields.add(uuidPropertyName);
-                        }
-                        List<String> cIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
-                        List<String> sIndexFields = IndexHelper.getSingleIndexFields(indexFields);
-                        List<String> newSIndexFields = indexHelper.getNewFields(parentVertex, sIndexFields, false);
-                       
-                        List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();               
-                        List<String> newUniqueIndexFields = indexHelper.getNewFields(parentVertex, indexUniqueFields, true);
-                        
-                        Indexer indexer = new Indexer(dbProvider);
-                        indexer.setSingleIndexFields(newSIndexFields);
-                        indexer.setCompositeIndexFields(cIndexFields);
 
-                        indexer.setUniqueIndexFields(newUniqueIndexFields);
-                        status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
-                        logger.info("CREATE INDEX STATUS ====== " + status);
-                        if(status){
-                            indexHelper.updateParentIndexProperty(parentVertex, indexFields, indexUniqueFields);
-                        }
-                                  
-                    dbProvider.commitTransaction(graph, tx);
-                    indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status); 
+                    try (OSGraph osGraph = dbProvider.getOSGraph()) {
+                        Graph graph = osGraph.getGraphStore();
+                        try (Transaction tx = dbProvider.startTransaction(graph)) {
 
-                    
+                            List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
+                            if (!indexFields.contains(uuidPropertyName)) {
+                                // adds default field (uuid)
+                                indexFields.add(uuidPropertyName);
+                            }
+                            List<String> cIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
+                            List<String> sIndexFields = IndexHelper.getSingleIndexFields(indexFields);
+                            List<String> newSIndexFields = indexHelper.getNewFields(parentVertex, sIndexFields, false);
+
+                            List<String> indexUniqueFields = definition.getOsSchemaConfiguration()
+                                    .getUniqueIndexFields();
+                            List<String> newUniqueIndexFields = indexHelper.getNewFields(parentVertex,
+                                    indexUniqueFields, true);
+
+                            Indexer indexer = new Indexer(dbProvider);
+                            indexer.setSingleIndexFields(newSIndexFields);
+                            indexer.setCompositeIndexFields(cIndexFields);
+
+                            indexer.setUniqueIndexFields(newUniqueIndexFields);
+                            status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
+                            logger.info("CREATE INDEX STATUS ====== " + status);
+                            if (status) {
+                                indexHelper.updateParentIndexProperty(parentVertex, indexFields, indexUniqueFields);
+                            }
+
+                            dbProvider.commitTransaction(graph, tx);
+                            indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status);
+                        }
+                    }
+
                 } catch (Exception e) {
                     status = false;
                     logger.error(e.getMessage());
@@ -273,9 +270,10 @@ public class EntityParenter {
                 }
             } else {
                 logger.info("No definition found for create index");
-            } 
-            
-        }).start();           
+            }
+
+        }).start();
+
     }
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -240,11 +240,12 @@ public class EntityParenter {
                     
                         
                         List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
-                        // adds default field (uuid)
-                        indexFields.add(uuidPropertyName);
+                        if(!indexFields.contains(uuidPropertyName)){
+                            // adds default field (uuid)
+                            indexFields.add(uuidPropertyName);
+                        }
                         List<String> cIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
                         List<String> sIndexFields = IndexHelper.getSingleIndexFields(indexFields);
-                        List<String> newCIndexFields = indexHelper.getNewFields(parentVertex, cIndexFields, false);
                         List<String> newSIndexFields = indexHelper.getNewFields(parentVertex, sIndexFields, false);
                        
                         List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();               
@@ -252,7 +253,8 @@ public class EntityParenter {
                         
                         Indexer indexer = new Indexer(dbProvider);
                         indexer.setSingleIndexFields(newSIndexFields);
-                        indexer.setCompositeIndexFields(newCIndexFields);
+                        indexer.setCompositeIndexFields(cIndexFields);
+
                         indexer.setUniqueIndexFields(newUniqueIndexFields);
                         status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
                         logger.info("CREATE INDEX STATUS ====== " + status);

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -68,11 +68,15 @@ public class EntityParenter {
               Vertex parentVertex = shardParentInfo.getVertex();
               List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
               List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
-
-              int nNewIndices = indexHelper.getNewFields(parentVertex, indexFields, false).size();
-              int nNewUniqIndices = indexHelper.getNewFields(parentVertex, indexUniqueFields, true).size();
               
-              boolean indexingComplete = (nNewIndices == 0 && nNewUniqIndices == 0);
+              List<String> compositeIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
+              List<String> singleIndexFields = IndexHelper.getSingleIndexFields(indexFields);
+
+              int nNewIndices = indexHelper.getNewFields(parentVertex, singleIndexFields, false).size();
+              int nNewUniqIndices = indexHelper.getNewFields(parentVertex, indexUniqueFields, true).size();
+              int nNewCompIndices = indexHelper.getNewFields(parentVertex, compositeIndexFields, false).size();
+            
+              boolean indexingComplete = (nNewIndices == 0 && nNewUniqIndices == 0 && nNewCompIndices == 0);
               indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), indexingComplete);
               logger.info("On loadDefinitionIndex for Shard:"+ shardId + " definition: {} updated index to {} ", definition.getTitle(), indexingComplete);
               
@@ -227,41 +231,44 @@ public class EntityParenter {
      */
     private void asyncAddIndex(DatabaseProvider dbProvider, String shardId, Vertex parentVertex, Definition definition) {
         new Thread(() -> {
-          try{
-                boolean createIndexSkipped = false;
-                OSGraph osGraph = dbProvider.getOSGraph();
-                Graph graph = osGraph.getGraphStore();
-                Transaction tx = dbProvider.startTransaction(graph);           
-                if(parentVertex != null && definition != null){
-                    List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
-                    // adds default field (uuid)
-                    indexFields.add(uuidPropertyName);
-                    List<String> newIndexFields = indexHelper.getNewFields(parentVertex, indexFields, false);
-                    List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();               
-                    List<String> newUniqueIndexFields = indexHelper.getNewFields(parentVertex, indexUniqueFields, true);
-
-                    Indexer indexer = new Indexer(dbProvider);
-                    indexer.setIndexFields(newIndexFields);
-                    indexer.setUniqueIndexFields(newUniqueIndexFields);
-                    if ((newIndexFields.size() != 0 && newIndexFields.size() != indexFields.size()) ||
-                        (newUniqueIndexFields.size() != 0 && newUniqueIndexFields.size() != indexUniqueFields.size())) {
-                        // Dont attempt create index on a fresh database
-                        indexer.createIndex(graph, definition.getTitle(), parentVertex);
-                    } else { 
-                        createIndexSkipped = true;
-                    }
-                } else {
-                    logger.info("No definition found for create index");
-                }               
-                dbProvider.commitTransaction(graph, tx);
-                if (!createIndexSkipped) {
-                    indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), true);
+            if(parentVertex != null && definition != null){
+                boolean status = false;
+                try {
+                    OSGraph osGraph = dbProvider.getOSGraph();
+                    Graph graph = osGraph.getGraphStore();
+                    Transaction tx = dbProvider.startTransaction(graph);           
+                    
+                        
+                        List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
+                        // adds default field (uuid)
+                        indexFields.add(uuidPropertyName);
+                        List<String> cIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
+                        List<String> sIndexFields = IndexHelper.getSingleIndexFields(indexFields);
+                        List<String> newCIndexFields = indexHelper.getNewFields(parentVertex, cIndexFields, false);
+                        List<String> newSIndexFields = indexHelper.getNewFields(parentVertex, sIndexFields, false);
+                       
+                        List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();               
+                        List<String> newUniqueIndexFields = indexHelper.getNewFields(parentVertex, indexUniqueFields, true);
+                        
+                        Indexer indexer = new Indexer(dbProvider);
+                        indexer.setSingleIndexFields(newSIndexFields);
+                        indexer.setCompositeIndexFields(newCIndexFields);
+                        indexer.setUniqueIndexFields(newUniqueIndexFields);
+                        status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
+                        logger.info("CREATE INDEX ====== " + status);
+    
+                                  
+                    dbProvider.commitTransaction(graph, tx);
+                } catch (Exception e) {
+                    status = false;
+                    logger.error(e.getMessage());
+                    logger.error("Failed Transaction creating index {}", definition.getTitle());
                 }
-          } catch (Exception e) {
-              logger.error(e.getMessage());
-              logger.error("Failed to create index {}", definition.getTitle());
-             
-          }      
+                indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status); 
+            } else {
+                logger.info("No definition found for create index");
+            } 
+            
         }).start();           
     }
 

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -224,56 +224,75 @@ public class EntityParenter {
 
     private void asyncAddIndex(DatabaseProvider dbProvider, String shardId, Vertex parentVertex,
             Definition definition) {
-        new Thread(() -> {
-            if (parentVertex != null && definition != null) {
-                boolean status = false;
-                try {
-
-                    try (OSGraph osGraph = dbProvider.getOSGraph()) {
-                        Graph graph = osGraph.getGraphStore();
-                        try (Transaction tx = dbProvider.startTransaction(graph)) {
-
-                            List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
-                            if (!indexFields.contains(uuidPropertyName)) {
-                                // adds default field (uuid)
-                                indexFields.add(uuidPropertyName);
-                            }
-                            List<String> cIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
-                            List<String> sIndexFields = IndexHelper.getSingleIndexFields(indexFields);
-                            List<String> newSIndexFields = indexHelper.getNewFields(parentVertex, sIndexFields, false);
-
-                            List<String> indexUniqueFields = definition.getOsSchemaConfiguration()
-                                    .getUniqueIndexFields();
-                            List<String> newUniqueIndexFields = indexHelper.getNewFields(parentVertex,
-                                    indexUniqueFields, true);
-
-                            Indexer indexer = new Indexer(dbProvider);
-                            indexer.setSingleIndexFields(newSIndexFields);
-                            indexer.setCompositeIndexFields(cIndexFields);
-
-                            indexer.setUniqueIndexFields(newUniqueIndexFields);
-                            status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
-                            logger.info("CREATE INDEX STATUS ====== " + status);
-                            if (status) {
-                                indexHelper.updateParentIndexProperty(parentVertex, indexFields, indexUniqueFields);
-                            }
-
-                            dbProvider.commitTransaction(graph, tx);
-                            indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status);
-                        }
-                    }
-
-                } catch (Exception e) {
-                    status = false;
-                    logger.error(e.getMessage());
-                    logger.error("Failed Transaction creating index {}", definition.getTitle());
-                }
-            } else {
-                logger.info("No definition found for create index");
+        // new Thread(() -> {
+        if (parentVertex != null && definition != null) {
+            boolean status = false;
+            List<String> indexFields = definition.getOsSchemaConfiguration().getIndexFields();
+            if (!indexFields.contains(uuidPropertyName)) {                
+                indexFields.add(uuidPropertyName); // adds default field (uuid)
             }
+            List<String> indexUniqueFields = definition.getOsSchemaConfiguration().getUniqueIndexFields();
+            try (OSGraph osGraph = dbProvider.getOSGraph()) {
+                Graph graph = osGraph.getGraphStore();
+                try (Transaction tx = dbProvider.startTransaction(graph)) {
 
-        }).start();
+                    List<String> cIndexFields = IndexHelper.getCompositeIndexFields(indexFields);
+                    List<String> sIndexFields = IndexHelper.getSingleIndexFields(indexFields);
+                    List<String> newSIndexFields = indexHelper.getNewFields(parentVertex, sIndexFields, false);
+                    List<String> newUniqueIndexFields = indexHelper.getNewFields(parentVertex, indexUniqueFields, true);
+                    Indexer indexer = new Indexer(dbProvider);
+                    indexer.setSingleIndexFields(newSIndexFields);
+                    indexer.setCompositeIndexFields(cIndexFields);
 
+                    indexer.setUniqueIndexFields(newUniqueIndexFields);
+                    status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
+                    logger.info("CREATE INDEX STATUS ====== " + status);
+
+                    dbProvider.commitTransaction(graph, tx);
+                }
+            } catch (Exception e) {
+                status = false;
+                logger.error(e.getMessage());
+                logger.error("Failed Transaction creating index {}", definition.getTitle());
+            }
+            if (status) {
+                updateParentVertexIndexProperties(dbProvider, parentVertex.label(), indexFields, indexUniqueFields);
+            }
+            indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status);
+
+        } else {
+            logger.info("No definition found for create index");
+        }
+
+        // }).start();
+
+    }
+
+    /**
+     * Updates the group/parent vertex index properties.
+     * 
+     * @param dbProvider
+     * @param parentlabel
+     * @param indexFields
+     * @param indexUniqueFields
+     */
+    private void updateParentVertexIndexProperties(DatabaseProvider dbProvider, String parentlabel,
+            List<String> indexFields, List<String> indexUniqueFields) {
+        try {
+            try (OSGraph osGraph = dbProvider.getOSGraph()) {
+                Graph graph = osGraph.getGraphStore();
+                try (Transaction tx = dbProvider.startTransaction(graph)) {
+                    VertexWriter vertexWriter = new VertexWriter(graph, dbProvider, uuidPropertyName);
+                    vertexWriter.updateParentIndexProperty(parentlabel, indexFields, indexUniqueFields);
+                    dbProvider.commitTransaction(graph, tx);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.error(e.getMessage());
+            logger.error("Failed Transaction updating parent index properties {}", e);
+
+        }
     }
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -256,15 +256,19 @@ public class EntityParenter {
                         indexer.setUniqueIndexFields(newUniqueIndexFields);
                         status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
                         logger.info("CREATE INDEX STATUS ====== " + status);
-    
+                        if(status){
+                            indexHelper.updateParentIndexProperty(parentVertex, indexFields, indexUniqueFields);
+                        }
                                   
                     dbProvider.commitTransaction(graph, tx);
+                    indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status); 
+
+                    
                 } catch (Exception e) {
                     status = false;
                     logger.error(e.getMessage());
                     logger.error("Failed Transaction creating index {}", definition.getTitle());
                 }
-                indexHelper.updateDefinitionIndex(shardId, definition.getTitle(), status); 
             } else {
                 logger.info("No definition found for create index");
             } 

--- a/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/EntityParenter.java
@@ -255,7 +255,7 @@ public class EntityParenter {
                         indexer.setCompositeIndexFields(newCIndexFields);
                         indexer.setUniqueIndexFields(newUniqueIndexFields);
                         status = indexer.createIndex(graph, definition.getTitle(), parentVertex);
-                        logger.info("CREATE INDEX ====== " + status);
+                        logger.info("CREATE INDEX STATUS ====== " + status);
     
                                   
                     dbProvider.commitTransaction(graph, tx);

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -46,36 +46,6 @@ public class IndexHelper {
         logger.debug("isIndexPresent flag for {}: {}", defTitle, isIndexPresent);
         return isIndexPresent;
     }
-    
-    /**
-     * Updates INDEX_FIELDS(single, composite) and UNIQUE_INDEX_FIELDS property of parent vertex
-     * @param parentVertex
-     */
-    public void updateParentIndexProperty(Vertex parentVertex, List<String> indexFields, List<String> uniqueIndexFields) { 
-
-        //Non-unique
-        if (indexFields.size() > 0) {
-            replaceVertexProperty(parentVertex, indexFields, false);
-        }
-        //unique
-        if(uniqueIndexFields.size() > 0){
-            replaceVertexProperty(parentVertex, uniqueIndexFields, true);
-  
-        }
-    }
-    /**
-     * Replace the INDEX_FIELDS and UNIQUE_INDEX_FIELDS of parent vertex
-     * @param parentVertex
-     * @param properties
-     * @param isUnique
-     */
-    private void replaceVertexProperty(Vertex parentVertex, List<String> indexFields, boolean isUnique){
-        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
-        StringBuilder properties = new StringBuilder(String.join(",", indexFields));
-        parentVertex.property(propertyName, properties.toString());
-        logger.info("parent vertex property {}:{}", propertyName, properties);
-    }
-
 
     /**
      * Identifies new fields for creating index. Parent vertex are always have

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -2,9 +2,13 @@ package io.opensaber.registry.util;
 
 import io.opensaber.registry.middleware.util.Constants;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,6 +71,38 @@ public class IndexHelper {
                 newFields.add(field);
         }
         return newFields;
+    }
+    
+    //TODO: optimizations required
+    //get substr = "(" between values ")".
+    public static List<String> getCompositeIndexFields(List<String> fields){
+        if(fields.size()>0){
+            StringBuilder list = new StringBuilder(String.join(",",fields));
+            String subString = StringUtils.substringBetween(list.toString(), "(", ")").replaceAll("'", "");
+            String[] commaSeparatedArr = subString.split("\\s*,\\s*");
+            List<String> result = Arrays.stream(commaSeparatedArr).collect(Collectors.toList());
+            return result;
+        } else {
+            return new ArrayList<>();
+        }
+
+    }
+    
+    //TODO: optimizations required
+    public static List<String> getSingleIndexFields(List<String> fields){
+        if(fields.size()>0){
+            StringBuilder list = new StringBuilder(String.join(",", fields));
+            String subString = (StringUtils.substringBetween(list.toString(), "(", ")"));
+            String orginal = list.toString().replaceAll(subString, "").replaceAll(Pattern.quote("()"), "");
+
+            String[] commaSeparatedArr = orginal.split(",");
+            List<String> result = Arrays.stream(commaSeparatedArr).collect(Collectors.toList());
+            return result;
+        } else {
+            return new ArrayList<>();
+
+        }
+
     }
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -17,19 +17,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class IndexHelper {
     private static Logger logger = LoggerFactory.getLogger(IndexHelper.class);
-    
+
     /**
-     * Holds mapping for each shard & each definitions and its index status 
-     * key = shardId+definitionName 
-     * value = true/false
+     * Holds mapping for each shard & each definitions and its index status key
+     * = shardId+definitionName value = true/false
      */
     private Map<String, Boolean> definitionIndexMap = new ConcurrentHashMap<String, Boolean>();
- 
+
     public void setDefinitionIndexMap(Map<String, Boolean> definitionIndexMap) {
         this.definitionIndexMap.putAll(definitionIndexMap);
     }
-   
-    public void updateDefinitionIndex(String label, String definitionName, boolean flag){
+
+    public void updateDefinitionIndex(String label, String definitionName, boolean flag) {
         String key = label + definitionName;
         definitionIndexMap.put(key, flag);
     }
@@ -45,7 +44,7 @@ public class IndexHelper {
         String defTitle = definition.getTitle();
         boolean isIndexPresent = definitionIndexMap.getOrDefault(shardId + defTitle, false);
         logger.debug("isIndexPresent flag for {}: {}", defTitle, isIndexPresent);
-        return isIndexPresent;       
+        return isIndexPresent;
     }
 
     /**
@@ -72,12 +71,15 @@ public class IndexHelper {
         }
         return newFields;
     }
-    
-    //TODO: optimizations required
-    //get substr = "(" between values ")".
-    public static List<String> getCompositeIndexFields(List<String> fields){
-        if(fields.size()>0){
-            StringBuilder list = new StringBuilder(String.join(",",fields));
+
+    /**
+     * extract values between "( values with comma separated )"
+     * @param fields
+     * @return
+     */
+    public static List<String> getCompositeIndexFields(List<String> fields) {
+        if (fields.size() > 0) {
+            StringBuilder list = new StringBuilder(String.join(",", fields));
             String subString = StringUtils.substringBetween(list.toString(), "(", ")").replaceAll("'", "");
             String[] commaSeparatedArr = subString.split("\\s*,\\s*");
             List<String> result = Arrays.stream(commaSeparatedArr).collect(Collectors.toList());
@@ -87,10 +89,13 @@ public class IndexHelper {
         }
 
     }
-    
-    //TODO: optimizations required
-    public static List<String> getSingleIndexFields(List<String> fields){
-        if(fields.size()>0){
+    /**
+     * Remove fields with format = "( values with comma separated )"
+     * @param fields
+     * @return
+     */
+    public static List<String> getSingleIndexFields(List<String> fields) {
+        if (fields.size() > 0) {
             StringBuilder list = new StringBuilder(String.join(",", fields));
             String subString = (StringUtils.substringBetween(list.toString(), "(", ")"));
             String orginal = list.toString().replaceAll(subString, "").replaceAll(Pattern.quote("()"), "");

--- a/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/IndexHelper.java
@@ -19,8 +19,8 @@ public class IndexHelper {
     private static Logger logger = LoggerFactory.getLogger(IndexHelper.class);
 
     /**
-     * Holds mapping for each shard & each definitions and its index status key
-     * = shardId+definitionName value = true/false
+     * Holds mapping for each shard & each definitions and its index status 
+     * key = shardId+definitionName value = true/false
      */
     private Map<String, Boolean> definitionIndexMap = new ConcurrentHashMap<String, Boolean>();
 
@@ -46,6 +46,36 @@ public class IndexHelper {
         logger.debug("isIndexPresent flag for {}: {}", defTitle, isIndexPresent);
         return isIndexPresent;
     }
+    
+    /**
+     * Updates INDEX_FIELDS(single, composite) and UNIQUE_INDEX_FIELDS property of parent vertex
+     * @param parentVertex
+     */
+    public void updateParentIndexProperty(Vertex parentVertex, List<String> indexFields, List<String> uniqueIndexFields) { 
+
+        //Non-unique
+        if (indexFields.size() > 0) {
+            replaceVertexProperty(parentVertex, indexFields, false);
+        }
+        //unique
+        if(uniqueIndexFields.size() > 0){
+            replaceVertexProperty(parentVertex, uniqueIndexFields, true);
+  
+        }
+    }
+    /**
+     * Replace the INDEX_FIELDS and UNIQUE_INDEX_FIELDS of parent vertex
+     * @param parentVertex
+     * @param properties
+     * @param isUnique
+     */
+    private void replaceVertexProperty(Vertex parentVertex, List<String> indexFields, boolean isUnique){
+        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
+        StringBuilder properties = new StringBuilder(String.join(",", indexFields));
+        parentVertex.property(propertyName, properties.toString());
+        logger.info("parent vertex property {}:{}", propertyName, properties);
+    }
+
 
     /**
      * Identifies new fields for creating index. Parent vertex are always have

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -67,11 +67,12 @@ public class Indexer {
      * @param label     type vertex label (example:Teacher) and table in rdbms           
      * @param parentVertex
      */
-    public boolean createIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
+    public boolean createIndex(Graph graph, String label, Vertex parentVertex) {
         boolean isCreated = false;
         if (label != null && !label.isEmpty()) {
             try {
-                createNonUniqueIndex(graph, label, parentVertex);
+                createSingleIndex(graph, label, parentVertex);
+                createCompositeIndex(graph, label, parentVertex);
                 createUniqueIndex(graph, label, parentVertex);
                 updateIndices(parentVertex);
                 isCreated = true;
@@ -85,17 +86,27 @@ public class Indexer {
         return isCreated;
     }
     /**
-     * Creates single and composite indices
+     * Creates single indices
      * @param graph
      * @param label
      * @param parentVertex
      * @throws NoSuchElementException
      */
-    private void createNonUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
+    private void createSingleIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
         databaseProvider.createIndex(graph, label, singleIndexFields);        
-        databaseProvider.createCompositeIndex(graph, label, compositeIndexFields);
 
     }
+    /**
+     * Creates composite indices
+     * @param graph
+     * @param label
+     * @param parentVertex
+     * @throws NoSuchElementException
+     */
+    private void createCompositeIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
+        databaseProvider.createCompositeIndex(graph, label, compositeIndexFields);
+    }
+    
     /**
      * Creates only unique indices
      * @param graph

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -16,11 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Indexer {
     private static Logger logger = LoggerFactory.getLogger(Indexer.class);
-/*
-    *//**
-     * Non unique index fields 
-     *//*
-    private List<String> indexFields;*/
+
     /**
      * Unique index fields
      */
@@ -39,15 +35,6 @@ public class Indexer {
         this.databaseProvider = databaseProvider;
     }
 
-/*    *//**
-     * Required to set non-unique fields to create
-     * 
-     * @param indexFields
-     *//*
-    public void setIndexFields(List<String> indexFields) {
-        this.indexFields = indexFields;
-    }
-*/
     /**
      * Required to set unique fields to create
      * 
@@ -89,7 +76,6 @@ public class Indexer {
                 updateIndices(parentVertex);
                 isCreated = true;
             } catch (Exception e) {
-                // TODO Auto-generated catch block
                 logger.error(e.getMessage());
                 logger.error("Failed to create index {}", label);
             }
@@ -98,48 +84,42 @@ public class Indexer {
         }
         return isCreated;
     }
-
+    /**
+     * Creates single and composite indices
+     * @param graph
+     * @param label
+     * @param parentVertex
+     * @throws NoSuchElementException
+     */
     private void createNonUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
         databaseProvider.createIndex(graph, label, singleIndexFields);        
         databaseProvider.createCompositeIndex(graph, label, compositeIndexFields);
 
     }
-
+    /**
+     * Creates only unique indices
+     * @param graph
+     * @param label
+     * @param parentVertex
+     * @throws NoSuchElementException
+     */
     private void createUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
         databaseProvider.createUniqueIndex(graph, label, indexUniqueFields);
     }
 
-/*    *//**
-     * Append the values to parent vertex INDEX_FIELDS and UNIQUE_INDEX_FIELDS
-     * property
-     * 
-     * @param parentVertex
-     * @param values
-     * @param isUnique
-     *//*
-    private void updateIndices(Vertex parentVertex, List<String> values, boolean isUnique) {
-        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
-
-        if (values.size() > 0) {
-            String properties = new StringBuilder(String.join(",", values)).toString();
-            parentVertex.property(propertyName, properties);
-            logger.info("parent vertex property {}:{}", propertyName, properties);
-        } else {
-            logger.info("no values to set for parent vertex property for {}", propertyName);
-        }
-    }*/
     /**
-     * 
+     * Updates INDEX_FIELDS(single, composite) and UNIQUE_INDEX_FIELDS property of parent vertex
      * @param parentVertex
      */
-    private void updateIndices(Vertex parentVertex) {  
+    private void updateIndices(Vertex parentVertex) { 
+        //Non-unique
         if (singleIndexFields.size() > 0 && compositeIndexFields.size() > 0) {
             StringBuilder sproperties = new StringBuilder(String.join(",", singleIndexFields));
             StringBuilder cproperties = sproperties.append(",(").append(String.join(",", compositeIndexFields)).append(")");
-            //sproperties.append(cproperties);
             replaceVertexProperty(parentVertex, cproperties.toString(), false);
 
         }
+        //unique
         if(indexUniqueFields.size() > 0){
             StringBuilder properties = new StringBuilder(String.join(",", indexUniqueFields));
             replaceVertexProperty(parentVertex, properties.toString(), true);

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -70,9 +70,9 @@ public class Indexer {
         boolean isCreated = false;
         if (label != null && !label.isEmpty()) {
             try {
+                createUniqueIndex(graph, label, parentVertex);
                 createSingleIndex(graph, label, parentVertex);
                 createCompositeIndex(graph, label, parentVertex);
-                createUniqueIndex(graph, label, parentVertex);
                 isCreated = true;
             } catch (Exception e) {
                 logger.error(e.getMessage());

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -1,6 +1,5 @@
 package io.opensaber.registry.util;
 
-import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.sink.DatabaseProvider;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -74,7 +73,6 @@ public class Indexer {
                 createSingleIndex(graph, label, parentVertex);
                 createCompositeIndex(graph, label, parentVertex);
                 createUniqueIndex(graph, label, parentVertex);
-                updateIndices(parentVertex);
                 isCreated = true;
             } catch (Exception e) {
                 logger.error(e.getMessage());
@@ -116,37 +114,6 @@ public class Indexer {
      */
     private void createUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
         databaseProvider.createUniqueIndex(graph, label, indexUniqueFields);
-    }
-
-    /**
-     * Updates INDEX_FIELDS(single, composite) and UNIQUE_INDEX_FIELDS property of parent vertex
-     * @param parentVertex
-     */
-    private void updateIndices(Vertex parentVertex) { 
-        //Non-unique
-        if (singleIndexFields.size() > 0 && compositeIndexFields.size() > 0) {
-            StringBuilder sproperties = new StringBuilder(String.join(",", singleIndexFields));
-            StringBuilder cproperties = sproperties.append(",(").append(String.join(",", compositeIndexFields)).append(")");
-            replaceVertexProperty(parentVertex, cproperties.toString(), false);
-
-        }
-        //unique
-        if(indexUniqueFields.size() > 0){
-            StringBuilder properties = new StringBuilder(String.join(",", indexUniqueFields));
-            replaceVertexProperty(parentVertex, properties.toString(), true);
-  
-        }
-    }
-    /**
-     * Replace the INDEX_FIELDS and UNIQUE_INDEX_FIELDS of parent vertex
-     * @param parentVertex
-     * @param properties
-     * @param isUnique
-     */
-    private void replaceVertexProperty(Vertex parentVertex, String properties, boolean isUnique){
-        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
-        parentVertex.property(propertyName, properties);
-        logger.info("parent vertex property {}:{}", propertyName, properties);
     }
     
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -66,24 +66,15 @@ public class Indexer {
      * @param label     type vertex label (example:Teacher) and table in rdbms           
      * @param parentVertex
      */
-    public boolean createIndex(Graph graph, String label, Vertex parentVertex) {
-        boolean isCreated = false;
+    public void createIndex(Graph graph, String label, Vertex parentVertex) throws Exception{
+
         if (label != null && !label.isEmpty()) {
-            try {
-                
-                createUniqueIndex(graph, label, parentVertex);
-                createSingleIndex(graph, label, parentVertex);
-                createCompositeIndex(graph, label, parentVertex);
-                
-                isCreated = true;
-            } catch (Exception e) {
-                logger.error(e.getMessage());
-                logger.error("Failed to create index {}", label);
-            }
+            createUniqueIndex(graph, label, parentVertex);
+            createSingleIndex(graph, label, parentVertex);
+            createCompositeIndex(graph, label, parentVertex);
         } else {
             logger.info("label is required for creating indexing");
         }
-        return isCreated;
     }
     /**
      * Creates single indices

--- a/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Indexer.java
@@ -16,30 +16,38 @@ import org.slf4j.LoggerFactory;
  */
 public class Indexer {
     private static Logger logger = LoggerFactory.getLogger(Indexer.class);
-
-    /**
+/*
+    *//**
      * Non unique index fields 
-     */
-    private List<String> indexFields;
+     *//*
+    private List<String> indexFields;*/
     /**
      * Unique index fields
      */
     private List<String> indexUniqueFields;
+    /**
+     * Composite index fields
+     */
+    private List<String> compositeIndexFields;
+    /**
+     * Single index fields
+     */
+    private List<String> singleIndexFields;
     private DatabaseProvider databaseProvider;
 
     public Indexer(DatabaseProvider databaseProvider) {
         this.databaseProvider = databaseProvider;
     }
 
-    /**
+/*    *//**
      * Required to set non-unique fields to create
      * 
      * @param indexFields
-     */
+     *//*
     public void setIndexFields(List<String> indexFields) {
         this.indexFields = indexFields;
     }
-
+*/
     /**
      * Required to set unique fields to create
      * 
@@ -47,6 +55,22 @@ public class Indexer {
      */
     public void setUniqueIndexFields(List<String> indexUniqueFields) {
         this.indexUniqueFields = indexUniqueFields;
+    }
+    /**
+     * Required to set single fields to create
+     * 
+     * @param indexUniqueFields
+     */
+    public void setSingleIndexFields(List<String> singleIndexFields) {
+        this.singleIndexFields = singleIndexFields;
+    }
+    /**
+     * Required to set composite fields to create
+     * 
+     * @param indexUniqueFields
+     */
+    public void setCompositeIndexFields(List<String> compositeIndexFields) {
+        this.compositeIndexFields = compositeIndexFields;
     }
 
     /**
@@ -56,50 +80,82 @@ public class Indexer {
      * @param label     type vertex label (example:Teacher) and table in rdbms           
      * @param parentVertex
      */
-    public void createIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
+    public boolean createIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
+        boolean isCreated = false;
         if (label != null && !label.isEmpty()) {
-            createNonUniqueIndex(graph, label, parentVertex);
-            createUniqueIndex(graph, label, parentVertex);
+            try {
+                createNonUniqueIndex(graph, label, parentVertex);
+                createUniqueIndex(graph, label, parentVertex);
+                updateIndices(parentVertex);
+                isCreated = true;
+            } catch (Exception e) {
+                // TODO Auto-generated catch block
+                logger.error(e.getMessage());
+                logger.error("Failed to create index {}", label);
+            }
         } else {
             logger.info("label is required for creating indexing");
         }
+        return isCreated;
     }
 
     private void createNonUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
-
-        databaseProvider.createIndex(graph, label, indexFields);
-        updateIndices(parentVertex, indexFields, false);
+        databaseProvider.createIndex(graph, label, singleIndexFields);        
+        databaseProvider.createCompositeIndex(graph, label, compositeIndexFields);
 
     }
 
     private void createUniqueIndex(Graph graph, String label, Vertex parentVertex) throws NoSuchElementException {
-
         databaseProvider.createUniqueIndex(graph, label, indexUniqueFields);
-        updateIndices(parentVertex, indexUniqueFields, true);
-
     }
 
-    /**
+/*    *//**
      * Append the values to parent vertex INDEX_FIELDS and UNIQUE_INDEX_FIELDS
      * property
      * 
      * @param parentVertex
      * @param values
      * @param isUnique
-     */
+     *//*
     private void updateIndices(Vertex parentVertex, List<String> values, boolean isUnique) {
         String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
 
         if (values.size() > 0) {
-            String existingValue = (String) parentVertex.property(propertyName).value();
-            for (String value : values) {
-                existingValue = existingValue.isEmpty() ? value : (existingValue + "," + value);
-                parentVertex.property(propertyName, existingValue);
-            }
-            logger.info("parent vertex property {}:{}", propertyName, existingValue);
+            String properties = new StringBuilder(String.join(",", values)).toString();
+            parentVertex.property(propertyName, properties);
+            logger.info("parent vertex property {}:{}", propertyName, properties);
         } else {
             logger.info("no values to set for parent vertex property for {}", propertyName);
         }
-    }
+    }*/
+    /**
+     * 
+     * @param parentVertex
+     */
+    private void updateIndices(Vertex parentVertex) {  
+        if (singleIndexFields.size() > 0 && compositeIndexFields.size() > 0) {
+            StringBuilder sproperties = new StringBuilder(String.join(",", singleIndexFields));
+            StringBuilder cproperties = sproperties.append(",(").append(String.join(",", compositeIndexFields)).append(")");
+            //sproperties.append(cproperties);
+            replaceVertexProperty(parentVertex, cproperties.toString(), false);
 
+        }
+        if(indexUniqueFields.size() > 0){
+            StringBuilder properties = new StringBuilder(String.join(",", indexUniqueFields));
+            replaceVertexProperty(parentVertex, properties.toString(), true);
+  
+        }
+    }
+    /**
+     * Replace the INDEX_FIELDS and UNIQUE_INDEX_FIELDS of parent vertex
+     * @param parentVertex
+     * @param properties
+     * @param isUnique
+     */
+    private void replaceVertexProperty(Vertex parentVertex, String properties, boolean isUnique){
+        String propertyName = isUnique ? Constants.UNIQUE_INDEX_FIELDS : Constants.INDEX_FIELDS;
+        parentVertex.property(propertyName, properties);
+        logger.info("parent vertex property {}:{}", propertyName, properties);
+    }
+    
 }

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -148,7 +148,7 @@
                       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
-         "indexFields": ["nationalIdentifier"],
+         "indexFields": ["(serialNum, birthDate)","nationalIdentifier"],
          "uniqueIndexFields": ["serialNum"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -144,7 +144,7 @@
          "osComment": ["This section contains the OpenSABER specific configuration information", 
                       "privateFields: Optional; list of field names to be encrypted and stored in database", 
                       "signedFields: Optional; list of field names that must be pre-signed",
-                      "indexFields: Optional; list of field names used for creating index",
+                      "indexFields: Optional; list of field names used for creating index. This field must specify as: [(a, b),c, d]; fields enclosed withing braces are for composite index and other fields are for single index",
                       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -144,7 +144,7 @@
          "osComment": ["This section contains the OpenSABER specific configuration information", 
                       "privateFields: Optional; list of field names to be encrypted and stored in database", 
                       "signedFields: Optional; list of field names that must be pre-signed",
-                      "indexFields: Optional; list of field names used for creating index. This field must specify as: [(a, b),c, d]; fields enclosed withing braces are for composite index and other fields are for single index",
+                      "indexFields: Optional; list of field names used for creating index. Enclose within braces to indicate it is a composite index. In this definition, (serialNum, teacherCode) is a composite index and teacherName is a single column index.",
                       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],

--- a/java/registry/src/main/resources/public/_schemas/Teacher.json
+++ b/java/registry/src/main/resources/public/_schemas/Teacher.json
@@ -148,7 +148,7 @@
                       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name"],                     
          "privateFields": ["nationalIdentifier", "teacherCode", "birthDate"],
          "signedFields": ["serialNum"],
-         "indexFields": ["(serialNum, birthDate)","nationalIdentifier"],
-         "uniqueIndexFields": ["serialNum"]
+         "indexFields": ["(serialNum, teacherCode)","teacherName"],
+         "uniqueIndexFields": ["serialNum", "teacherCode"]
   }
 }


### PR DESCRIPTION
Adding unique constraints to Neo4j database provider, constraints are added to create Index 
Unique index is kept for higher precedence than index(single, composite)
Resolved parent vertex property update:- by using graph traversal, hence moved the updateParentIndexProperty() to VertexWriter. Called in entityParenter with seperate transaction.
