### PR TITLE
Os 186: Search support for numeric operators

### DIFF
--- a/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
@@ -1,7 +1,5 @@
 package io.opensaber.pojos;
 
-import io.opensaber.pojos.FilterOperators.FilterOperator;
-
 public class Filter {
 	// Denotes the absolute path of the subject
 	private String path;
@@ -10,7 +8,7 @@ public class Filter {
 	private String property;
 
 	// The operator
-	private FilterOperator operator;
+	private FilterOperators operator;
 
 	// The value that needs to be searched
 	private Object value;
@@ -19,9 +17,9 @@ public class Filter {
 		this.path = path;
 	}
 
-	public Filter(String property, String operator, String value) {
+	public Filter(String property, FilterOperators operator, Object value) {
 		this.property = property;
-		//this.operator = operator;
+		this.operator = operator;
 		this.value = value;
 	}
 
@@ -49,7 +47,7 @@ public class Filter {
 		this.path = path;
 	}
 
-	public FilterOperator getOperator() { return this.operator;}
+	public FilterOperators getOperator() { return this.operator;}
 
-	public void setOperator(FilterOperator filterO) { this.operator = filterO; }
+	public void setOperator(FilterOperators operator) { this.operator = operator; }
 }

--- a/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
@@ -1,5 +1,7 @@
 package io.opensaber.pojos;
 
+import io.opensaber.pojos.FilterOperators.FilterOperator;
+
 public class Filter {
 	// Denotes the absolute path of the subject
 	private String path;
@@ -8,7 +10,7 @@ public class Filter {
 	private String property;
 
 	// The operator
-	private FilterOperators operator;
+	private FilterOperator operator;
 
 	// The value that needs to be searched
 	private Object value;
@@ -47,7 +49,7 @@ public class Filter {
 		this.path = path;
 	}
 
-	public FilterOperators getOperator() { return this.operator;}
+	public FilterOperator getOperator() { return this.operator;}
 
-	public void setOperator(FilterOperators operator) { this.operator = operator; }
+	public void setOperator(FilterOperator filterO) { this.operator = filterO; }
 }

--- a/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
@@ -8,7 +8,7 @@ public class Filter {
 	private String property;
 
 	// The operator
-	private String operator;
+	private FilterOperators operator;
 
 	// The value that needs to be searched
 	private String value;
@@ -47,7 +47,7 @@ public class Filter {
 		this.path = path;
 	}
 
-	public String getOperator() { return this.operator;}
+	public FilterOperators getOperator() { return this.operator;}
 
-	public void setOperator(String operator) { this.operator = operator; }
+	public void setOperator(FilterOperators operator) { this.operator = operator; }
 }

--- a/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/Filter.java
@@ -11,7 +11,7 @@ public class Filter {
 	private FilterOperators operator;
 
 	// The value that needs to be searched
-	private String value;
+	private Object value;
 
 	public Filter(String path) {
 		this.path = path;
@@ -33,11 +33,11 @@ public class Filter {
 		return operator;
 	}*/
 
-	public String getValue() {
+	public Object getValue() {
 		return value;
 	}
 
-	public void setValue(String value) { this.value = value; }
+	public void setValue(Object object) { this.value = object; }
 
 	public String getPath() {
 		return path;

--- a/java/pojos/src/main/java/io/opensaber/pojos/FilterOperators.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/FilterOperators.java
@@ -1,8 +1,9 @@
 package io.opensaber.pojos;
 
 public enum FilterOperators {
-    gte("gte"), lte("lte"), contains("contains"), equals("eq"),
-    gt(">"), lt("<"), eq("=");
+    gte(">="), lte("<="), contains("contains"),
+    gt(">"), lt("<"), eq("="),
+    between("bet");
 
     private String name;
 
@@ -12,9 +13,5 @@ public enum FilterOperators {
 
     public String getName() {
         return name;
-    }
-    
-    public enum FilterOperator{
-        eq, lt, gt, gte, lte, between
     }
 }

--- a/java/pojos/src/main/java/io/opensaber/pojos/FilterOperators.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/FilterOperators.java
@@ -3,15 +3,29 @@ package io.opensaber.pojos;
 public enum FilterOperators {
     gte(">="), lte("<="), contains("contains"),
     gt(">"), lt("<"), eq("="),
-    between("bet");
+    between("range");
 
-    private String name;
+    private String value;
 
-    FilterOperators(String name) {
-        this.name = name;
+    FilterOperators(String value) {
+        this.value = value;
     }
 
-    public String getName() {
-        return name;
+    public String getValue() {
+        return value;
+    }
+       
+    public static FilterOperators get(String name){
+        FilterOperators filterOperators = null;
+        try {
+            filterOperators = FilterOperators.valueOf(name);
+        } catch (IllegalArgumentException e){
+            for (FilterOperators operators : FilterOperators.values()) {
+                if (operators.getValue().equals(name)) {
+                    filterOperators = operators;
+                }
+            }
+        }
+        return filterOperators;
     }
 }

--- a/java/pojos/src/main/java/io/opensaber/pojos/FilterOperators.java
+++ b/java/pojos/src/main/java/io/opensaber/pojos/FilterOperators.java
@@ -13,4 +13,8 @@ public enum FilterOperators {
     public String getName() {
         return name;
     }
+    
+    public enum FilterOperator{
+        eq, lt, gt, gte, lte, between
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -1,20 +1,20 @@
 package io.opensaber.registry.dao;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.opensaber.pojos.Filter;
+import io.opensaber.pojos.FilterOperators;
 import io.opensaber.pojos.SearchQuery;
-import io.opensaber.registry.middleware.util.*;
-import io.opensaber.registry.util.*;
+import io.opensaber.registry.middleware.util.Constants;
+import io.opensaber.registry.util.ReadConfigurator;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import java.util.*;
 
 public class SearchDaoImpl implements SearchDao {
     private IRegistryDao registryDao;
@@ -35,13 +35,13 @@ public class SearchDaoImpl implements SearchDao {
 			for (Filter filter : filterList) {
 				String property = filter.getProperty();
 				String genericValue = filter.getValue();
-				String operator = filter.getOperator();
+				FilterOperators operator = filter.getOperator();
 				String path = filter.getPath();
 
 				//List valueList = getValueList(value);
 
 				// Defaulting to "equals" operation
-				if (operator == null || operator == "=") {
+				if (operator == null || operator == FilterOperators.eq) {
 					resultGraphTraversal = resultGraphTraversal.has(property,
 							P.eq(genericValue));
 				}

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -16,7 +16,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-
 public class SearchDaoImpl implements SearchDao {
     private IRegistryDao registryDao;
 
@@ -24,23 +23,22 @@ public class SearchDaoImpl implements SearchDao {
         registryDao = registryDaoImpl;
     }
 
-    public JsonNode search(Graph graphFromStore, SearchQuery searchQuery) {
+	public JsonNode search(Graph graphFromStore, SearchQuery searchQuery) {
 
-        GraphTraversalSource dbGraphTraversalSource = graphFromStore.traversal().clone();
-        List<Filter> filterList = searchQuery.getFilters();
-        GraphTraversal<Vertex, Vertex> resultGraphTraversal = dbGraphTraversalSource.clone().V()
-                .hasLabel(searchQuery.getRootLabel());
+		GraphTraversalSource dbGraphTraversalSource = graphFromStore.traversal().clone();
+		List<Filter> filterList = searchQuery.getFilters();
+		GraphTraversal<Vertex, Vertex> resultGraphTraversal = dbGraphTraversalSource.clone().V().hasLabel(searchQuery.getRootLabel());
 
-        List<P> predicates = new ArrayList<>();
-        // Ensure the root label is correct
-        if (filterList != null) {
-            for (Filter filter : filterList) {
-                String property = filter.getProperty();
-                Object genericValue = filter.getValue();
-                FilterOperator operator = filter.getOperator();
-                String path = filter.getPath();
+		List<P> predicates = new ArrayList<>();
+		// Ensure the root label is correct
+		if (filterList != null) {
+			for (Filter filter : filterList) {
+				String property = filter.getProperty();
+				Object genericValue = filter.getValue();
+				FilterOperator operator = filter.getOperator();
+				String path = filter.getPath();
 
-                // List valueList = getValueList(value);
+				//List valueList = getValueList(value);
 
                 switch (operator) {
                 case eq:
@@ -67,16 +65,16 @@ public class SearchDaoImpl implements SearchDao {
                     break;
                 }
 
-                if (path != null) {
-                    if (resultGraphTraversal.asAdmin().clone().hasNext()) {
-                        resultGraphTraversal = resultGraphTraversal.asAdmin().clone().outE(path).outV();
-                    }
-                }
-            }
-        }
+				if (path != null) {
+					if (resultGraphTraversal.asAdmin().clone().hasNext()) {
+						resultGraphTraversal = resultGraphTraversal.asAdmin().clone().outE(path).outV();
+					}
+				}
+			}
+		}
 
-        return getResult(graphFromStore, resultGraphTraversal);
-    }
+		return getResult(graphFromStore, resultGraphTraversal);
+	}
 
 	private void updateValueList(Object value, List valueList) {
 		valueList.add(value);

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -34,7 +34,7 @@ public class SearchDaoImpl implements SearchDao {
 		if (filterList != null) {
 			for (Filter filter : filterList) {
 				String property = filter.getProperty();
-				String genericValue = filter.getValue();
+				Object genericValue = filter.getValue();
 				FilterOperators operator = filter.getOperator();
 				String path = filter.getPath();
 

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -59,8 +59,7 @@ public class SearchDaoImpl implements SearchDao {
                     break;
                 case between:
                     List<Object> objects = (List<Object>) genericValue;
-                    resultGraphTraversal = resultGraphTraversal.has(property,
-                            P.between(objects.get(0), objects.get(objects.size() - 1)));
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.between(objects.get(0), objects.get(objects.size() - 1)));
                     break;
                 default:
                     resultGraphTraversal = resultGraphTraversal.has(property, P.eq(genericValue));

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -54,7 +54,7 @@ public class SearchDaoImpl implements SearchDao {
                     resultGraphTraversal = resultGraphTraversal.has(property, P.gte(genericValue));
                     break;
                 case lte:
-                    resultGraphTraversal = resultGraphTraversal.has(property, P.gte(genericValue));
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.lte(genericValue));
                     break;
                 case between:
                     List<Object> objects = (List<Object>) genericValue;

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.opensaber.pojos.Filter;
-import io.opensaber.pojos.FilterOperators;
+import io.opensaber.pojos.FilterOperators.FilterOperator;
 import io.opensaber.pojos.SearchQuery;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.util.ReadConfigurator;
@@ -35,16 +35,32 @@ public class SearchDaoImpl implements SearchDao {
 			for (Filter filter : filterList) {
 				String property = filter.getProperty();
 				Object genericValue = filter.getValue();
-				FilterOperators operator = filter.getOperator();
+				FilterOperator operator = filter.getOperator();
 				String path = filter.getPath();
 
 				//List valueList = getValueList(value);
 
-				// Defaulting to "equals" operation
-				if (operator == null || operator == FilterOperators.eq) {
-					resultGraphTraversal = resultGraphTraversal.has(property,
-							P.eq(genericValue));
-				}
+				switch (operator) {
+                case eq:
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.eq(genericValue));
+                    break;
+                case gt:
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.gt(genericValue));
+                    break;
+                case lt:
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.lt(genericValue));
+                    break;
+                case gte:
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.gte(genericValue));
+                    break;
+                case lte:
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.gte(genericValue));
+                    break;
+                default:
+                    resultGraphTraversal = resultGraphTraversal.has(property, P.eq(genericValue));
+                    break;
+                }
+								
 				if (path != null) {
 					if (resultGraphTraversal.asAdmin().clone().hasNext()) {
 						resultGraphTraversal = resultGraphTraversal.asAdmin().clone().outE(path).outV();

--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.opensaber.pojos.Filter;
-import io.opensaber.pojos.FilterOperators.FilterOperator;
+import io.opensaber.pojos.FilterOperators;
 import io.opensaber.pojos.SearchQuery;
 import io.opensaber.registry.middleware.util.Constants;
 import io.opensaber.registry.util.ReadConfigurator;
@@ -35,7 +35,7 @@ public class SearchDaoImpl implements SearchDao {
 			for (Filter filter : filterList) {
 				String property = filter.getProperty();
 				Object genericValue = filter.getValue();
-				FilterOperator operator = filter.getOperator();
+				FilterOperators operator = filter.getOperator();
 				String path = filter.getPath();
 
 				//List valueList = getValueList(value);

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
@@ -10,6 +10,7 @@ import io.opensaber.pojos.SearchQuery;
 import io.opensaber.registry.dao.IRegistryDao;
 import io.opensaber.registry.dao.RegistryDaoImpl;
 import io.opensaber.registry.dao.SearchDaoImpl;
+import io.opensaber.registry.dao.ValueType;
 import io.opensaber.registry.middleware.util.JSONUtil;
 import io.opensaber.registry.model.DBConnectionInfo;
 import io.opensaber.registry.model.DBConnectionInfoMgr;
@@ -83,7 +84,7 @@ public class SearchServiceImpl implements SearchService {
 				Filter filter = new Filter(path);
 				filter.setProperty(entry.getKey());
 				filter.setOperator(FilterOperators.eq);
-				filter.setValue(entryVal.asText());
+				filter.setValue(ValueType.getValue(entryVal));
 				filterList.add(filter);
 			}
 		}

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
@@ -5,8 +5,11 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opensaber.pojos.Filter;
+import io.opensaber.pojos.FilterOperators;
 import io.opensaber.pojos.SearchQuery;
-import io.opensaber.registry.dao.*;
+import io.opensaber.registry.dao.IRegistryDao;
+import io.opensaber.registry.dao.RegistryDaoImpl;
+import io.opensaber.registry.dao.SearchDaoImpl;
 import io.opensaber.registry.middleware.util.JSONUtil;
 import io.opensaber.registry.model.DBConnectionInfo;
 import io.opensaber.registry.model.DBConnectionInfoMgr;
@@ -16,6 +19,11 @@ import io.opensaber.registry.sink.shard.Shard;
 import io.opensaber.registry.sink.shard.ShardManager;
 import io.opensaber.registry.util.DefinitionsManager;
 import io.opensaber.registry.util.RecordIdentifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.slf4j.Logger;
@@ -23,12 +31,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 @Component
 public class SearchServiceImpl implements SearchService {
@@ -80,7 +82,7 @@ public class SearchServiceImpl implements SearchService {
 			} else if (entryVal.isValueNode()){
 				Filter filter = new Filter(path);
 				filter.setProperty(entry.getKey());
-				filter.setOperator("=");
+				filter.setOperator(FilterOperators.eq);
 				filter.setValue(entryVal.asText());
 				filterList.add(filter);
 			}

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
@@ -80,7 +80,16 @@ public class SearchServiceImpl implements SearchService {
             JsonNode entryVal = entry.getValue();
             if (entryVal.isObject() && (entryVal.fields().hasNext())) {
                 Map.Entry<String, JsonNode> json = entryVal.fields().next();
-                if (json.getValue().isValueNode()) {
+                if (json.getValue().isArray()) {
+                    List<Object> ol = getRange(json);
+                    String operator = json.getKey();
+                    Filter filter = new Filter(path);
+                    String property = entry.getKey();
+                    filter.setProperty(property);
+                    filter.setValue(ol);
+                    filter.setOperator(FilterOperator.valueOf(operator));
+                    filterList.add(filter);
+                } else if (json.getValue().isValueNode()) {
                     String operator = json.getKey();
                     Filter filter = new Filter(path);
                     String property = entry.getKey();
@@ -95,6 +104,17 @@ public class SearchServiceImpl implements SearchService {
 
             }
         }
+    }
+
+    private List<Object> getRange(Map.Entry<String, JsonNode> entry) {
+        List<Object> rangeValues = new ArrayList<>();
+        JsonNode array = entry.getValue();
+        for (int i = 0; i < array.size(); i++) {
+            JsonNode entryVal = entry.getValue().get(i);
+            if (entryVal.isValueNode())
+                rangeValues.add(ValueType.getValue(entryVal));
+        }
+        return rangeValues;
     }
 
 	@Override

--- a/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/impl/SearchServiceImpl.java
@@ -80,22 +80,18 @@ public class SearchServiceImpl implements SearchService {
             JsonNode entryVal = entry.getValue();
             if (entryVal.isObject() && (entryVal.fields().hasNext())) {
                 Map.Entry<String, JsonNode> json = entryVal.fields().next();
+                String operator = json.getKey();
+                Filter filter = new Filter(path);
+                String property = entry.getKey();
+                filter.setProperty(property);
+                filter.setOperator(FilterOperator.valueOf(operator));
+
                 if (json.getValue().isArray()) {
                     List<Object> ol = getRange(json);
-                    String operator = json.getKey();
-                    Filter filter = new Filter(path);
-                    String property = entry.getKey();
-                    filter.setProperty(property);
                     filter.setValue(ol);
-                    filter.setOperator(FilterOperator.valueOf(operator));
                     filterList.add(filter);
                 } else if (json.getValue().isValueNode()) {
-                    String operator = json.getKey();
-                    Filter filter = new Filter(path);
-                    String property = entry.getKey();
-                    filter.setProperty(property);
                     filter.setValue(ValueType.getValue(json.getValue()));
-                    filter.setOperator(FilterOperator.valueOf(operator));
                     filterList.add(filter);
 
                 } else if (json.getValue().isObject()) {

--- a/java/registry/src/test/java/io/opensaber/registry/dao/impl/SearchDaoImplTest.java
+++ b/java/registry/src/test/java/io/opensaber/registry/dao/impl/SearchDaoImplTest.java
@@ -1,7 +1,10 @@
 package io.opensaber.registry.dao.impl;
 
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.opensaber.pojos.Filter;
+import io.opensaber.pojos.FilterOperators;
 import io.opensaber.pojos.SearchQuery;
 import io.opensaber.registry.app.OpenSaberApplication;
 import io.opensaber.registry.config.GenericConfiguration;
@@ -12,6 +15,9 @@ import io.opensaber.registry.exception.AuditFailedException;
 import io.opensaber.registry.exception.EncryptionException;
 import io.opensaber.registry.exception.RecordNotFoundException;
 import io.opensaber.registry.middleware.util.Constants;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.Before;
@@ -24,12 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertTrue;
 
 @Ignore
 @RunWith(SpringRunner.class)
@@ -70,7 +70,7 @@ public class SearchDaoImplTest extends RegistryTestBase {
 	}
 
 	private Filter getFilterEqual(String property, String value) {
-		Filter filter = new Filter(property, "=", value);
+		Filter filter = new Filter(property, FilterOperators.eq, value);
 		return filter;
 	}
 }


### PR DESCRIPTION
Search Api supports for numeric operators added.
Numeric operators extended supports are: **gte, gt, lte, lt**
NOTE: default is eq (=)
Below request payload change:
```
{
  "request": {
    "Teacher": {
      "serialNum": { "gt": 1 },
      "gender": { "eq": "GenderTypeCode-MALE" }
    }
  }
}
```

Numeric operator for range ( between )
```
{
  "request": {
    "Teacher": {
      "serialNum": {"between":[1,3]}
    }
  }
}
```
Tested: 
For ranges: if array [] is empty OR if array[1] contains single element OR  if array[2,1] descending order; Empty result returned.
if array elements size not 2 ; Exception raised 