### PR TITLE
OS#207 Fix Elastic-search and os-actors version incorrectness

### DIFF
--- a/java/elastic-search/pom.xml
+++ b/java/elastic-search/pom.xml
@@ -1,20 +1,20 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.opensaber</groupId>
     <artifactId>elastic-search</artifactId>
-    <version>2.0.1</version>
     <name>Elastic-Search</name>
     <description>Elastic Search for OS</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-        <jacoco.version>0.8.1</jacoco.version>
-        <elastic.search.version>6.6.0</elastic.search.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+    <parent>
+        <artifactId>opensaber</artifactId>
+        <groupId>io.opensaber</groupId>
+        <version>2.0.2</version>
+    </parent>
 
+    <properties>
+        <elastic.search.version>6.6.0</elastic.search.version>
     </properties>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.elasticsearch/elasticsearch -->
         <dependency>
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>pojos</artifactId>
-            <version>2.0.2</version>
+            <version>${version}</version>
         </dependency>
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>2.0.2</version>
+            <version>${version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.springframework.retry/spring-retry -->

--- a/java/opensaber-actors/pom.xml
+++ b/java/opensaber-actors/pom.xml
@@ -15,18 +15,18 @@
         <dependency>
             <groupId>org.sunbird.akka</groupId>
             <artifactId>sunbird-actor</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>elastic-search</artifactId>
-            <version>2.0.1</version>
+            <version>${version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>opensaber-audit</artifactId>
-            <version>2.0.1</version>
+            <version>${version}</version>
         </dependency>
     </dependencies>
 

--- a/java/opensaber-audit/pom.xml
+++ b/java/opensaber-audit/pom.xml
@@ -1,30 +1,27 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.opensaber</groupId>
+
     <artifactId>opensaber-audit</artifactId>
-    <version>2.0.1</version>
     <name>Opensaber-Audit</name>
     <description>Audit for OS</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-        <jacoco.version>0.8.1</jacoco.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+    <parent>
+        <artifactId>opensaber</artifactId>
+        <groupId>io.opensaber</groupId>
+        <version>2.0.2</version>
+    </parent>
 
-    </properties>
     <dependencies>
-
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>pojos</artifactId>
-            <version>2.0.2</version>
+            <version>${version}</version>
         </dependency>
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>middleware-commons</artifactId>
-            <version>2.0.2</version>
+            <version>${version}</version>
         </dependency>
 
         <dependency>

--- a/java/registry/pom.xml
+++ b/java/registry/pom.xml
@@ -63,19 +63,19 @@
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>registry-interceptor</artifactId>
-            <version>2.0.2</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>elastic-search</artifactId>
-            <version>2.0.1</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
             <groupId>io.opensaber</groupId>
             <artifactId>opensaber-actors</artifactId>
-            <version>2.0.2</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -138,10 +138,10 @@ signature:
     config:
       name: SignatureShape
 
-audit:
-  enabled: ${audit_enabled:false}
-  frame:
-    file: ${audit_frame_file:audit_frame.json}
+#audit:
+  #enabled: ${audit_enabled:false}
+  #frame:
+    #file: ${audit_frame_file:audit_frame.json}
 
 authentication:
   enabled: ${authentication_enabled:true}

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/registry-app.log</file>
+        <file>logs/app.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
             <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -21,35 +21,31 @@
         </encoder>
     </appender>
 
-    <appender name="RegistryAuditAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/registry_neo4j.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>logFile.%d{yyyy-MM-dd-hh}-%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>10</maxIndex>
-        </rollingPolicy>
+    <!--<appender name="RegistryAuditAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
+        <!--<file>logs/audit.log</file>-->
+        <!--<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">-->
+            <!--<fileNamePattern>auditlog.%d{yyyy-MM-dd-hh}-%i.log</fileNamePattern>-->
+        <!--</rollingPolicy>-->
+        <!--<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">-->
+            <!--<maxFileSize>10KB</maxFileSize>-->
+        <!--</triggeringPolicy>-->
 
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <Pattern>
-                %d %msg%n
-            </Pattern>
-        </encoder>
-    </appender>
+        <!--<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">-->
+            <!--<Pattern>-->
+                <!--%d %msg%n-->
+            <!--</Pattern>-->
+        <!--</encoder>-->
+    <!--</appender>-->
 
 
     <appender name="Perf4jFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <File>logs/registry_perf_instrumentation.log</File>
+        <file>logs/perf.log</file>
         <encoder>
             <!-- <Pattern>%date %-5level [%thread] %logger{36} [%file:%line] %msg%n -->
-            <Pattern>%date %-5level %msg%n
-            </Pattern>
+            <Pattern>%date %-5level %msg%n</Pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>logs/registry_perf_instrumentation.%d{yyyy-MM-dd}.log</FileNamePattern>
+            <FileNamePattern>logs/perf.%d{yyyy-MM-dd}.log</FileNamePattern>
         </rollingPolicy>
     </appender>
 
@@ -59,16 +55,17 @@
     </appender>
 
     <appender name="AuditFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/audit.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>audit-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>logs/audit-%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
             <totalSizeCap>5GB</totalSizeCap>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>3MB</maxFileSize>
+            <maxFileSize>10MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
-            <pattern>[%thread] %-5level %logger{50} - %msg%n</pattern>
+            <pattern>%msg%n</pattern>
         </encoder>
     </appender>
 
@@ -91,15 +88,15 @@
     <logger name="io.opensaber.registry.dao.RegistryDaoImpl" level="DEBUG"/>
     <logger name="com.mchange.v2.c3p0.impl.NewProxyPreparedStatement" level="DEBUG"/>
 
-    <logger name="GraphEventLogger" level="DEBUG" additivity="FALSE">
-        <appender-ref ref="RegistryAuditAppender"/>
-    </logger>
+    <!--<logger name="GraphEventLogger" level="DEBUG" additivity="FALSE">-->
+        <!--<appender-ref ref="RegistryAuditAppender"/>-->
+    <!--</logger>-->
 
     <logger name="io.opensaber.audit.AuditServiceImpl" level="DEBUG" additivity="FALSE">
         <appender-ref ref="AuditFileAppender"/>
     </logger>
 
-    <root level="DEBUG" additivity="FALSE">
+    <root level="INFO" additivity="FALSE">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>
     </root>


### PR DESCRIPTION
Noticed while doing testing that the pom dependency versions are incorrect and not hierarchical. Fixed them to ensure only 2.0.2 is used for all dependents and 1.0.0 is used for viewTemplates. Apart from this, we would have org.sunbird.akka which is also 1.0.0
While doing some perf tests, I found our log filenames are not that clear. Simplified naming to app , perf and audit.