### PR TITLE
Os 210 Logback rotations enabled

### DIFF
--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -8,35 +8,18 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/app.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
-
-            <!-- keep 10 days' worth of history -->
-            <maxHistory>10</maxHistory>
+            <fileNamePattern>logs/logFile.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
+            <maxFileSize>30MB</maxFileSize>
+            <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
+            <!-- <maxHistory>10</maxHistory> -->
+            <!-- <totalSizeCap>20GB</totalSizeCap> -->           
         </rollingPolicy>
-
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>
     </appender>
-
-    <!--<appender name="RegistryAuditAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
-        <!--<file>logs/audit.log</file>-->
-        <!--<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">-->
-            <!--<fileNamePattern>auditlog.%d{yyyy-MM-dd-hh}-%i.log</fileNamePattern>-->
-        <!--</rollingPolicy>-->
-        <!--<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">-->
-            <!--<maxFileSize>10KB</maxFileSize>-->
-        <!--</triggeringPolicy>-->
-
-        <!--<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">-->
-            <!--<Pattern>-->
-                <!--%d %msg%n-->
-            <!--</Pattern>-->
-        <!--</encoder>-->
-    <!--</appender>-->
-
 
     <appender name="Perf4jFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/perf.log</file>
@@ -44,8 +27,12 @@
             <!-- <Pattern>%date %-5level [%thread] %logger{36} [%file:%line] %msg%n -->
             <Pattern>%date %-5level %msg%n</Pattern>
         </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <FileNamePattern>logs/perf.%d{yyyy-MM-dd}.log</FileNamePattern>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <FileNamePattern>logs/perf.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</FileNamePattern>
+            <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
+            <!-- <maxHistory>10</maxHistory> -->
+            <!-- <totalSizeCap>5GB</totalSizeCap> -->
+            <maxFileSize>30MB</maxFileSize> 
         </rollingPolicy>
     </appender>
 
@@ -55,15 +42,14 @@
     </appender>
 
     <appender name="AuditFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/audit-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>5GB</totalSizeCap>
+        <file>audit_logs/audit.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>audit_logs/audit-%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
+            <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
+            <!-- <maxHistory>10</maxHistory> -->
+            <!-- <totalSizeCap>5GB</totalSizeCap> -->
+            <maxFileSize>30MB</maxFileSize>            
         </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
         <encoder>
             <pattern>%msg%n</pattern>
         </encoder>
@@ -87,10 +73,6 @@
     <logger name="com.steelbridgelabs.oss.neo4j.structure.Neo4JSession" level="DEBUG"/>
     <logger name="io.opensaber.registry.dao.RegistryDaoImpl" level="DEBUG"/>
     <logger name="com.mchange.v2.c3p0.impl.NewProxyPreparedStatement" level="DEBUG"/>
-
-    <!--<logger name="GraphEventLogger" level="DEBUG" additivity="FALSE">-->
-        <!--<appender-ref ref="RegistryAuditAppender"/>-->
-    <!--</logger>-->
 
     <logger name="io.opensaber.audit.AuditServiceImpl" level="DEBUG" additivity="FALSE">
         <appender-ref ref="AuditFileAppender"/>

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
         <file>logs/app.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>logs/app.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/app_%d{yyyy-MM-dd}_%d{HH-mm-ss}_%i.log</fileNamePattern>
             <maxFileSize>30MB</maxFileSize>
             <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
             <!-- <maxHistory>10</maxHistory> -->
@@ -28,7 +28,7 @@
             <Pattern>%date %-5level %msg%n</Pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <FileNamePattern>logs/perf.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</FileNamePattern>
+            <FileNamePattern>logs/perf_%d{yyyy-MM-dd}_%d{HH-mm-ss}_%i.log</FileNamePattern>
             <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
             <!-- <maxHistory>10</maxHistory> -->
             <!-- <totalSizeCap>5GB</totalSizeCap> -->
@@ -44,7 +44,7 @@
     <appender name="AuditFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>audit_logs/audit.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>audit_logs/audit.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
+            <fileNamePattern>audit_logs/audit_%d{yyyy-MM-dd}_%d{HH-mm-ss}_%i.log</fileNamePattern>
             <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
             <!-- <maxHistory>10</maxHistory> -->
             <!-- <totalSizeCap>5GB</totalSizeCap> -->

--- a/java/registry/src/main/resources/logback.xml
+++ b/java/registry/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
         <file>logs/app.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>logs/logFile.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/app.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
             <maxFileSize>30MB</maxFileSize>
             <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
             <!-- <maxHistory>10</maxHistory> -->
@@ -44,7 +44,7 @@
     <appender name="AuditFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>audit_logs/audit.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>audit_logs/audit-%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
+            <fileNamePattern>audit_logs/audit.%d{yyyy-MM-dd}_%d{HH-mm-ss}.%i.log</fileNamePattern>
             <!-- Adopter's specific tags: maxHistory, totalSizeCap disabled by default -->            
             <!-- <maxHistory>10</maxHistory> -->
             <!-- <totalSizeCap>5GB</totalSizeCap> -->


### PR DESCRIPTION
Logback rotations enabled on size limit 30Mb
MaxSize of log file could be 30Mb. If exceeds rotation takes place.
This rotation is done for perf logs, audit logs, app logs. 