### PR TITLE
OS#224 Create a sample UI for Person schema

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/app/OpenSaberApplication.java
+++ b/java/registry/src/main/java/io/opensaber/registry/app/OpenSaberApplication.java
@@ -1,13 +1,38 @@
 package io.opensaber.registry.app;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @SpringBootApplication
 @ComponentScan(basePackages = { "io.opensaber.registry", "io.opensaber.pojos"})
 public class OpenSaberApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(OpenSaberApplication.class, args);
+	}
+
+	@Value("${cors.allowedOrigin}")
+	public String corsAllowedOrigin;
+
+	@Bean
+	public FilterRegistrationBean corsFilter() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowCredentials(true);
+		config.addAllowedOrigin(corsAllowedOrigin);
+		config.addAllowedHeader("*");
+		config.addAllowedMethod("POST");
+		config.addAllowedMethod("DELETE");
+		config.addAllowedMethod("GET");
+		source.registerCorsConfiguration("/**", config);
+		FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+		bean.setOrder(0);
+		return bean;
 	}
 }

--- a/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/io/opensaber/registry/config/GenericConfiguration.java
@@ -27,6 +27,7 @@ import io.opensaber.registry.model.DBConnectionInfoMgr;
 import io.opensaber.registry.service.IReadService;
 import io.opensaber.registry.service.ISearchService;
 import io.opensaber.registry.sink.DBProviderFactory;
+import io.opensaber.registry.sink.shard.DefaultShardAdvisor;
 import io.opensaber.registry.sink.shard.IShardAdvisor;
 import io.opensaber.registry.sink.shard.ShardAdvisor;
 import io.opensaber.registry.transform.ConfigurationHelper;
@@ -75,6 +76,8 @@ import java.util.Map;
 public class GenericConfiguration implements WebMvcConfigurer {
 
 	private static Logger logger = LoggerFactory.getLogger(GenericConfiguration.class);
+	private final String NONE_STR = "none";
+
 	@Autowired
 	private DefinitionsManager definitionsManager;
 
@@ -271,7 +274,11 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	@Bean
 	public IShardAdvisor shardAdvisor() {		
 		ShardAdvisor shardAdvisor = new ShardAdvisor();
-		return shardAdvisor.getInstance(dbConnectionInfoMgr.getShardAdvisorClassName());
+		if (dbConnectionInfoMgr.getShardProperty().equals(NONE_STR)) {
+			return shardAdvisor.getInstance(DefaultShardAdvisor.class.getName());
+		} else {
+			return shardAdvisor.getInstance(dbConnectionInfoMgr.getShardAdvisorClassName());
+		}
 	}
     @Bean
     public ISearchService searchService() {       

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -13,10 +13,13 @@ name: dev-yaml
 enviroment: development
 
 server:
-  port: 8080
+  # Change this port number if you want to run it on another.
+  port: ${server_port:8080}
 
 cors:
-  allowedOrigin: ${cors_allowedOrigin:http://localhost:8080}
+  # By default, allowing all domains to access this service. Choose a particular domain,
+  # in production. For example, http://otherservice.com:9090, to allow requests from otherservice.com.
+  allowedOrigin: ${cors_allowedOrigin:*}
 
 perf:
   monitoring:

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -68,9 +68,11 @@ database:
   shardProperty: ${database_shardProperty:none}
   
   # This property is instruction to use the shard advisor.
-  # Values could be DefaultShardAdvisor, SerialNumberShardAdvisor
+  # Values could be io.opensaber.registry.sink.shard.DefaultShardAdvisor, OR
+  # io.opensaber.registry.sink.shard.SerialNumberShardAdvisor OR
+  # absolute class name of your advisor class.
   # If this property not provided, advisor is set to DefaultShardAdvisor
-  shardAdvisor: io.opensaber.registry.sink.shard.SerialNumberShardAdvisor
+  shardAdvisorClassName: io.opensaber.registry.sink.shard.DefaultShardAdvisor
 
   connectionInfo:
     -

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -12,9 +12,15 @@ spring:
 name: dev-yaml
 enviroment: development
 
+server:
+  port: 8080
+
+cors:
+  allowedOrigin: ${cors_allowedOrigin:http://localhost:8080}
+
 perf:
   monitoring:
-    enabled: ${perf_monitoring_enabled:true}
+    enabled: ${perf_monitoring_enabled:false}
 
 registry:
   context:

--- a/ui-sample/Person.html
+++ b/ui-sample/Person.html
@@ -1,0 +1,124 @@
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <link type="text/css" href="./alpaca.css" rel="stylesheet" />
+    <link type="text/css" rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
+    <link type="text/css" rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap-theme.min.css" >
+    <!--
+        <link type="text/css" href="http://code.cloudcms.com/alpaca/1.5.24/bootstrap/alpaca.min.css" rel="stylesheet" />
+    -->
+    <script type="text/javascript" src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
+    <script type="text/javascript" src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    
+    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.5/handlebars.js"></script>
+    <script type="text/javascript" src="http://code.cloudcms.com/alpaca/1.5.24/bootstrap/alpaca.min.js"></script>
+    <!--
+        In case you want to do GUI validation also.
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/ajv/4.1.7/ajv.bundle.js"></script>
+    -->
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
+    <!-- bootstrap datetimepicker for date and datetime controls -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/js/bootstrap-datetimepicker.min.js"></script>
+    <link rel="stylesheet" media="screen" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker-standalone.min.css"/>
+</head>
+
+<body>
+    <div id="PersonForm"></div>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            var cookedVal = {  "id": "",
+                                "ver": "1.0",
+                                "ets": "11234",
+                                "params": {
+                                    "did": "",
+                                    "key": "",
+                                    "msgid": ""
+                                },
+                                "request": {"Person": {}} 
+                            };
+            $("#PersonForm").alpaca({
+                "schemaSource": "./schema/Person.json",
+                "options": {
+                    "validate": true,
+                    "fields": {
+                        "dob": {
+                            "picker": {
+                                "useCurrent": false,
+                                "format": "YYYY-MM-DD",
+                                "locale": "en_US",
+                                "dayViewHeaderFormat": "MMMM YYYY",
+                                "extraFormats": []
+                            },
+                            "manualEntry": false,
+                            "fields": {}
+                        }
+                    },
+                    "form": {
+                        "attributes": {
+                            "method": "post",
+                            "action": "http://localhost:8080/add"
+                        },
+                        "buttons": {
+                            "validate": {
+                                "title": "Validate and view JSON!",
+                                "click": function () {
+                                    this.validate(true);
+                                    this.refreshValidationState(true);
+                                    if (this.isValid(true)) {
+                                        var value = this.getValue();
+                                        alert(JSON.stringify(value, null, "  "));
+                                    } else {
+                                        alert("not valid");
+                                    }
+                                }
+                            },
+                            "serialize": {
+                                "title": "Serialize",
+                                "click": function () {
+                                    var value = this.getValue();
+                                    alert(JSON.stringify(value, null, "  "));
+                                }
+                            },
+                            "add": {
+                                "title": "Add",
+                                "click": function () {
+                                    var value = this.getValue();
+                                    cookedVal["id"] = "open-saber.registry.create";
+                                    cookedVal["request"]["Person"] = value;
+                                    console.log(JSON.stringify(cookedVal));
+
+                                    $.ajax({url: "http://localhost:8080/add", 
+                                            type: "post", 
+                                            dataType: "application/json",
+                                            contentType: "application/json",
+                                            data: JSON.stringify(cookedVal)
+                                        }, function(data, status) {
+                                            alert("Data: " + JSON.stringify(data) + "\nStatus: " + status);
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    /*
+                    // If you want to display this form in any other layout.
+                    // 
+                    "view": {
+                        "parent": "bootstrap-edit",
+                        "layout": {
+                            "template": './layouts-example1-template.html',
+                            "bindings": {
+                                "firstName": "#left",
+                                "lastName": "#right"
+                            }
+                        }
+                    }*/
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/ui-sample/Person.html
+++ b/ui-sample/Person.html
@@ -2,9 +2,11 @@
 
 <head>
     <meta charset="UTF-8">
-    <link type="text/css" href="./alpaca.css" rel="stylesheet" />
     <link type="text/css" rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
-    <link type="text/css" rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap-theme.min.css" >
+    <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/todc-bootstrap/3.3.2-3.3.2/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" media="screen" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker-standalone.min.css"/>
+    <link type="text/css" href="./alpaca.css" rel="stylesheet" />
+   
     <!--
         <link type="text/css" href="http://code.cloudcms.com/alpaca/1.5.24/bootstrap/alpaca.min.css" rel="stylesheet" />
     -->
@@ -22,7 +24,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
     <!-- bootstrap datetimepicker for date and datetime controls -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/js/bootstrap-datetimepicker.min.js"></script>
-    <link rel="stylesheet" media="screen" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker-standalone.min.css"/>
 </head>
 
 <body>

--- a/ui-sample/README.md
+++ b/ui-sample/README.md
@@ -1,0 +1,6 @@
+This is a sample utility to demonstrate the OpenSABER API's.
+
+The schema is placed under "schema" folder. Presently, this works with the Person 
+schema provided in the src/main/resources.
+
+

--- a/ui-sample/alpaca.css
+++ b/ui-sample/alpaca.css
@@ -1,0 +1,654 @@
+/** Added to outer field elements to hide them **/
+.alpaca-hidden
+{
+    display: none;
+}
+
+/** Added to every field outer element **/
+.alpaca-field
+{
+    width: 50%
+}
+
+.btn
+{
+    left : 2%;
+}
+
+/** Added to every container outer field element **/
+.alpaca-container
+{
+   padding-left: 2%
+}
+
+/** Added to the optional label (or legend) accompanying any container **/
+.alpaca-container-label
+{
+
+}
+
+/** Added to every container item field within a container **/
+.alpaca-container-item
+{
+
+}
+
+/** Added to the first container item field within a container **/
+.alpaca-container-item-first
+{
+
+}
+
+/** Added to the last container item field within a container **/
+.alpaca-container-item-last
+{
+
+}
+
+/** Added to a container to indicate it is empty **/
+.alpaca-container-empty
+{
+
+}
+
+/** Added to the dom element holding the toolbar for an array **/
+.alpaca-array-toolbar
+{
+
+}
+
+/** Added to a button in the array toolbar that triggers an action **/
+.alpaca-array-toolbar-action
+{
+
+}
+
+/** Added to the dom element holding the actionbar for each array item **/
+.alpaca-array-actionbar
+{
+
+}
+
+/** Added to a button in an array item actionbar that triggers an action **/
+.alpaca-array-actionbar-action
+{
+
+}
+
+/** Added to every control outer field element **/
+.alpaca-control
+{
+
+}
+
+/** Added to the optional label accompanying any control **/
+.alpaca-control-label
+{
+
+}
+
+/** ******************************************************** **/
+/**                        STATE LABELS                      **/
+/** ******************************************************** **/
+
+/** Added to top-most control when rendering in display mode **/
+.alpaca-display
+{
+
+}
+
+/** Added to top-most control when rendering in create mode **/
+.alpaca-create
+{
+
+}
+
+/** Added to top-most control when rendering in edit mode **/
+.alpaca-edit
+{
+
+}
+
+/** Added to any field that is optional **/
+.alpaca-required
+{
+
+}
+
+.alpaca-required-indicator
+{
+    left: 2px;
+}
+
+/** Added to any field that is required **/
+.alpaca-optional
+{
+
+}
+
+/** Added to any field that is readonly **/
+.alpaca-readonly
+{
+
+}
+
+/** Added to any field that is disabled **/
+.alpaca-disabled
+{
+
+}
+
+/** Added to the container that holds Alpaca field helper text **/
+.alpaca-helper
+{
+
+}
+
+/** Added to form containers that are rendering in horizontal mode **/
+.alpaca-horizontal
+{
+
+}
+
+/** Added to form containers that are rendering in vertical mode **/
+.alpaca-vertical
+{
+
+}
+
+/** Added to the top most container element **/
+.alpaca-top
+{
+
+}
+
+/** Added to fields that are valid **/
+.alpaca-valid
+{
+
+}
+
+/** Added to fields that have run through validation and are invalid **/
+.alpaca-invalid
+{
+
+}
+
+/** Added to fields that have run through validation and are invalid but are currently hiding invalidation errors **/
+.alpaca-invalid-hidden
+{
+
+}
+
+/* Added to additional DOM elements to mark validation messages */
+.alpaca-message
+{
+
+}
+
+/** Added to messages that are for invalidation states that are current hidden (hideInitValidationError) **/
+.alpaca-message-hidden
+{
+
+}
+
+/** Added to buttons that are marked disabled */
+.alpaca-button-disabled
+{
+
+}
+
+
+
+/** ******************************************************** **/
+/**                           ICONS                          **/
+/** ******************************************************** **/
+
+.alpaca-icon-helper
+{
+
+}
+
+.alpaca-icon-required
+{
+
+}
+
+
+/** ******************************************************** **/
+/**                           OTHER                          **/
+/** ******************************************************** **/
+
+.alpaca-autocomplete
+{
+}
+
+
+
+/** Added to indicate hover state **/
+.alpaca-hover
+{
+}
+
+/** General purpose HTML clear **/
+.alpaca-clear
+{
+    clear: both;
+}
+
+.alpaca-float-right
+{
+    float: right;
+}
+
+
+.alpaca-form-button 
+{
+    box-sizing: border-box;
+    display: block;
+    float: left;
+    line-height: 20px;
+
+}
+
+/** ************************************** **/
+/** TWITTER TYPEAHEAD                      **/
+/** ************************************** **/
+
+.twitter-typeahead .tt-dropdown-menu
+{
+    background-color: white;
+    border: 1px #ccc solid;
+    padding: 10px;
+    color: #999;
+    width: 100%;
+    padding-bottom: 0px;
+}
+
+.twitter-typeahead .tt-dropdown-menu P
+{
+    font-size: 1em;
+}
+
+.tt-suggestion.tt-is-under-cursor
+{
+    background-color: #ccc;
+    color: #333;
+}
+
+.tt-dropdown-menu
+{
+    background-color: white;
+    border: 1px solid rgb(204, 204, 204);
+    width: 100%;
+}
+
+
+
+
+/** ************************************** **/
+/** EDITOR FIELD                           **/
+/** ************************************** **/
+
+.alpaca-controlfield-editor
+{
+    position: relative;
+    width: 100%;
+    height: 300px;
+    border: 1px #ccc solid;
+}
+
+.alpaca-controlfield-editor .control-field-editor-el
+{
+    position:absolute;
+    top:0;
+    bottom:0;
+    left: 0;
+    right:0
+}
+
+
+
+/** ************************************** **/
+/** DATEPICKER (jQueryUI)                  **/
+/** ************************************** **/
+
+#ui-datepicker-div
+{
+    display: none;
+    background-color:white;
+    z-index: 9999999 !important;
+    width: 22em !important;
+}
+
+/* Fix for Chrome issue with Button text */
+.ui-button .ui-button-text {
+    white-space: nowrap;
+}
+
+.ui-datepicker
+{
+    z-index: 100;
+}
+
+
+
+
+
+
+
+
+/** ************************************** **/
+/** FILE UPLOAD (jQueryUI)                 **/
+/** ************************************** **/
+
+.alpaca-fileupload-container
+{
+    border: 1px #ccc solid;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.alpaca-fileupload-container .row
+{
+    margin-bottom: 10px;
+}
+
+.alpaca-fileupload-well
+{
+    /*border: 1px #ccc solid;*/
+    padding: 10px;
+    border-radius: 5px;
+    min-height: 100px;
+}
+
+.alpaca-fileupload-container table
+{
+    border: 1px #ccc solid;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.alpaca-fileupload-well p
+{
+    padding-top: 20px;
+    color: #888;
+}
+
+.alpaca-fileupload-well table tbody.files tr td.name
+{
+    word-wrap: break-word;
+}
+
+
+
+
+
+
+
+/** ************************************** **/
+/** ACE EDITOR                             **/
+/** ************************************** **/
+
+.ace_editor
+{
+    border: 1px solid rgb(204, 204, 204);
+}
+
+
+
+/** ************************************** **/
+/** CK EDITOR                             **/
+/** ************************************** **/
+
+.alpaca-field-ckeditor.alpaca-invalid > .cke
+{
+    border-color: #f04124;
+}
+
+
+/** ************************************** **/
+/** OPTIONTREE                             **/
+/** ************************************** **/
+
+.alpaca-field-optiontree {
+
+}
+
+.alpaca-field-optiontree .optiontree {
+
+}
+
+.alpaca-field-optiontree .optiontree .optiontree-selector {
+
+}
+
+.alpaca-field-optiontree.optiontree-horizontal {
+
+}
+
+.alpaca-field-optiontree.optiontree-horizontal .optiontree {
+    display: inline-block;
+}
+
+.alpaca-field-optiontree.optiontree-horizontal .optiontree .optiontree-selector {
+    display: inline-block;
+    padding-left: 4px;
+}
+
+.alpaca-field-optiontree.optiontree-horizontal input {
+    display: inline-block;
+    width: auto;
+}
+
+.alpaca-field-optiontree.optiontree-horizontal label {
+    display: block;
+}
+
+
+
+/** ************************************** **/
+/** TABLE                                  **/
+/** ************************************** **/
+
+.alpaca-field-table .alpaca-field-tablerow label.control-label,
+table.dt-rowReorder-float .alpaca-field-tablerow label.control-label
+{
+    display: none;
+}
+
+.alpaca-field-table .actionbar, .table .actionbar,
+table.dt-rowReorder-float .actionbar, .table .actionbar
+{
+    white-space: nowrap;
+    text-align: center;
+}
+
+.alpaca-field-table table tr td .alpaca-field,
+table.dt-rowReorder-float tr td .alpaca-field
+{
+    width: 100%;
+}
+
+.alpaca-field-table table tr td .alpaca-field .form-control,
+table.dt-rowReorder-float tr td .alpaca-field .form-control
+{
+    width: 100%;
+}
+
+.alpaca-field-table .form-group,
+table.dt-rowReorder-float .form-group
+{
+    margin-bottom: 0px;
+}
+
+.alpaca-field-table .form-group.alpaca-field-checkbox,
+table.dt-rowReorder-float .form-group.alpaca-field-checkbox
+{
+    text-align: center;
+}
+
+.alpaca-field-table .alpaca-control.checkbox,
+table.dt-rowReorder-float .alpaca-control.checkbox
+{
+    padding-top: 6px;
+}
+
+.alpaca-field-table table tr td.actionbar .alpaca-array-actionbar,
+table.dt-rowReorder-float tr td.actionbar .alpaca-array-actionbar
+{
+    padding-bottom: 0px;
+    display: inline-block;
+}
+
+.alpaca-field-table .actionbar .alpaca-array-actionbar.btn-group,
+table.dt-rowReorder-float .actionbar .alpaca-array-actionbar.btn-group
+{
+    width: auto;
+}
+
+.alpaca-field-table .alpaca-table-column-hidden,
+table.dt-rowReorder-float .alpaca-table-column-hidden
+{
+    display: none;
+}
+
+.alpaca-field-table .alpaca-table-reorder-index-header,
+table.dt-rowReorder-float .alpaca-table-reorder-index-header
+{
+    display: none;
+}
+
+.alpaca-field-table .alpaca-table-reorder-index-cell,
+table.dt-rowReorder-float .alpaca-table-reorder-index-cell
+{
+    display: none;
+}
+
+.alpaca-field-table .alpaca-table-reorder-draggable-header,
+table.dt-rowReorder-float .alpaca-table-reorder-draggable-header
+{
+
+}
+
+.alpaca-field-table .alpaca-table-reorder-draggable-cell,
+table.dt-rowReorder-float .alpaca-table-reorder-draggable-cell
+{
+    color: #bbb;
+    font-size: 20px;
+    text-align: center;
+    vertical-align: middle;
+    padding-top: 11px;
+    cursor: pointer;
+}
+
+
+
+
+
+
+.alpaca-field-radio.disabled .alpaca-control.radio
+{
+    color: grey;
+}
+
+.alpaca-field-radio.disabled .alpaca-control.radio label
+{
+    cursor: inherit;
+}
+
+
+.alpaca-control.radio
+{
+    min-height: inherit;
+    height: inherit;
+    padding-top: 0px;
+    padding-bottom: 0px;
+    padding-left: 0px;
+    padding-right: 0px;
+    margin-left: 10px;
+}
+
+.alpaca-control.radio label
+{
+    line-height: 20px;
+}
+
+/** multiselect **/
+
+.has-error .multiselect
+{
+    border-color: #a94442;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+}
+
+.btn.multiselect
+{
+    white-space: normal;
+}
+
+.alpaca-field-table > legend
+{
+    display: none;
+}
+
+/*** CHOOSER **/
+
+.alpaca-field-chooser
+{
+
+}
+
+.alpaca-field-chooser .alpaca-control
+{
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-header
+{
+    min-height: 34px;
+    margin-bottom: 20px;
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-items
+{
+    background-color: white;
+    border: 1px #ccc solid;
+    border-radius: 4px;
+    overflow-y: scroll;
+    overflow-y: -moz-scrollbars-vertical;
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-items .chooser-item
+{
+    min-height: 34px;
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-items .chooser-item.disabled .chooser-item-text
+{
+    color: #ccc;
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-items .chooser-item:not(:last-child)
+{
+    border-bottom: 1px #ddd solid;
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-items .chooser-item .chooser-item-text
+{
+    margin-left: 10px;
+    line-height: 34px;
+    display: inline-block;
+}
+
+.alpaca-field-chooser .alpaca-control .chooser-panel .chooser-panel-items .chooser-item .chooser-item-buttons
+{
+    float: right;
+    margin: 5px;
+}
+
+.alpaca-field-chooser .chooser-item-message
+{
+    color: #aaa;
+}
+

--- a/ui-sample/alpaca.css
+++ b/ui-sample/alpaca.css
@@ -241,14 +241,15 @@
     float: right;
 }
 
-
 .alpaca-form-button 
 {
     box-sizing: border-box;
     display: block;
-    float: left;
     line-height: 20px;
-
+    border-color: #adadad;
+    background-color: #e0e0e0;
+    background-position: 0 -15px;
+    float: left;
 }
 
 /** ************************************** **/

--- a/ui-sample/schema/Person.json
+++ b/ui-sample/schema/Person.json
@@ -1,0 +1,56 @@
+{
+  "$id": "#/properties/Person",
+  "type": "object",
+  "title": "The Person Schema",
+  "required": [
+    "nationalIdentifier",
+    "name",
+    "gender",
+    "dob"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "photo": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "mediaType": "image/png",
+      "title": "photo"
+    },
+    "nationalIdentifier": {
+      "$id": "#/properties/nationalIdentifier",
+      "type": "string",
+      "$comment": "Nationality",
+      "title": "National identifier"
+    },
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "Full name"
+    },
+    "gender": {
+      "$id": "#/properties/gender",
+      "type": "string",
+      "enum": [
+        "MALE",
+        "FEMALE",
+        "OTHER"
+      ],
+      "title": "Gender"
+    },
+    "dob": {
+      "$id": "#/properties/birthDate",
+      "type": "string",
+      "format": "date",
+      "$comment": "YYYY-MM-DD format",
+      "examples": [
+        "1990-12-01"
+      ],
+      "title": "Date of birth"
+    },
+    "hasDrivingLicense": {
+      "$id": "#/properties/hasDrivingLicense",
+      "type": "boolean",
+      "title": "Driving license is present"
+    }
+  }
+}


### PR DESCRIPTION
Enabled CORS in the app so that adopters can quickly start integration. This was encountered even during our devcon days and we had enabled it then by hard-code. Now, I've externalised the origins to the configuration. 
Explicitly added port 8080 to application configuration. Thought this was already added, but find it missing.
Used Alpaca - a json-schema form generator to generate a dynamic form for the Person schema.
Turned off perf - default option must be that.
If the database shard is set to "none", the class name provided must be ignored. Presently, the class is attempted to instantiate and throws an exception.
The class name for shard advisor property was not specified properly and so was failing. 
Note: The last two items were part of OS-222, but being taken as the files are same.

Testing:
1. Able to do 'required' validations.
2. Able to add a record to the database from the UI.

As part of this PR, the following is not done:
1. Other than Add operations, we need some UI buttons and html files to showcase.
2. Validations to be done at UI level with ajv {another json schema validator}
3. Other cosmetic things like layout - this can be done using alpaca. A sample could be provided in our repo.

