### PR TITLE
OS-249 Fix search query for entire db rather than range

### DIFF
--- a/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
+++ b/java/registry/src/main/java/io/opensaber/registry/dao/SearchDaoImpl.java
@@ -32,11 +32,12 @@ public class SearchDaoImpl implements SearchDao {
         int offset = searchQuery.getOffset();
         ObjectNode resultNode = JsonNodeFactory.instance.objectNode();
         for (String entity : searchQuery.getEntityTypes()) {
-            GraphTraversal<Vertex, Vertex> resultGraphTraversal = dbGraphTraversalSource.clone().V().hasLabel(entity)
-                    .range(offset, offset + searchQuery.getLimit()).limit(searchQuery.getLimit());
-            GraphTraversal<Vertex, Vertex> parentTraversal = resultGraphTraversal.asAdmin().clone();
+            GraphTraversal<Vertex, Vertex> resultGraphTraversal = dbGraphTraversalSource.V().hasLabel(entity);
 
-            resultGraphTraversal = getFilteredResultTraversal(resultGraphTraversal, filterList);
+            GraphTraversal<Vertex, Vertex> parentTraversal = resultGraphTraversal.asAdmin();
+
+            resultGraphTraversal = getFilteredResultTraversal(resultGraphTraversal, filterList)
+                    .range(offset, offset + searchQuery.getLimit()).limit(searchQuery.getLimit());
             JsonNode result = getResult(graphFromStore, resultGraphTraversal, parentTraversal);
             resultNode.set(entity, result);
         }


### PR DESCRIPTION
Appears this is a long standing issue hidden. The filter criteria was applied only within the range specified. Therefore, if a match was available beyond the range the match didn't surface at all. This means search isn't working. I checked this is the behaviour in 2.0.2 and perhaps even earlier.

**Tests done**
Had search.limit set to 1 and 5 Person objects was used for all the following tests
1. Search a person, named P2 when P1 was the first person added (sequentially).
2. Invoked ab scripts to bombard the search and ensured everytime the result was returned (to ensure clone removal is fine).
3. Used offset and limit to navigate through the search results. Ensured P1 through P5 records were returned.