### PR TITLE
OS-257 Apply subschema configurations to private fields

### DIFF
--- a/java/middleware/registry-middleware/authorization/pom.xml
+++ b/java/middleware/registry-middleware/authorization/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/java/registry/src/main/java/io/opensaber/registry/service/DecryptionHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/DecryptionHelper.java
@@ -2,29 +2,21 @@ package io.opensaber.registry.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.opensaber.registry.exception.EncryptionException;
-import io.opensaber.registry.util.Definition;
 import io.opensaber.registry.util.PrivateField;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Map;
 
 @Component
 public class DecryptionHelper extends PrivateField {
 
     public JsonNode getDecryptedJson(JsonNode rootNode) throws EncryptionException {
-        JsonNode decryptedRoot = rootNode;
         String rootFieldName = rootNode.fieldNames().next();
-        Definition definition = definitionsManager.getDefinition(rootFieldName);
-        List<String> privatePropertyLst = definition.getOsSchemaConfiguration().getPrivateFields();
-        if (rootNode.isObject()) {
-            Map<String, Object> plainMap = getPrivateFields(rootNode, privatePropertyLst);
-            if(null != plainMap){
-                Map<String, Object> encodedMap = encryptionService.decrypt(plainMap);
-                decryptedRoot  = replacePrivateFields(rootNode, privatePropertyLst, encodedMap);
-            }
-        }
-        return decryptedRoot;
+        process(rootNode.get(rootFieldName), rootFieldName, null);
+        return rootNode;
     }
 
+    protected Map<String, Object> performOperation(Map<String, Object> plainMap) throws EncryptionException {
+        return encryptionService.decrypt(plainMap);
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/service/EncryptionHelper.java
+++ b/java/registry/src/main/java/io/opensaber/registry/service/EncryptionHelper.java
@@ -2,29 +2,21 @@ package io.opensaber.registry.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.opensaber.registry.exception.EncryptionException;
-import io.opensaber.registry.util.Definition;
 import io.opensaber.registry.util.PrivateField;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Map;
 
 @Component
 public class EncryptionHelper extends PrivateField {
-
-    public JsonNode getEncryptedJson(JsonNode rootNode) throws EncryptionException {
-        JsonNode encryptedRoot = rootNode;
-        String rootFieldName = rootNode.fieldNames().next();
-        Definition definition = definitionsManager.getDefinition(rootFieldName);
-        List<String> privatePropertyLst = definition.getOsSchemaConfiguration().getPrivateFields();
-        if (rootNode.isObject()) {
-            Map<String, Object> plainMap = getPrivateFields(rootNode, privatePropertyLst);
-            if(null != plainMap){
-                Map<String, Object> encodedMap = encryptionService.encrypt(plainMap);
-                encryptedRoot  = replacePrivateFields(rootNode, privatePropertyLst, encodedMap);
-            }
-        }
-        return encryptedRoot;
+    protected Map<String, Object> performOperation(Map<String, Object> plainMap) throws EncryptionException {
+        return encryptionService.encrypt(plainMap);
     }
 
+    public JsonNode getEncryptedJson(JsonNode rootNode) throws EncryptionException {
+        String rootFieldName = rootNode.fieldNames().next();
+        process(rootNode.get(rootFieldName), rootFieldName, null);
+
+        return rootNode;
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/Definition.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Definition.java
@@ -6,6 +6,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.json.Json;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Creates Definition for a given JsonNode This accepts a schema
  *
@@ -14,25 +18,32 @@ public class Definition {
     private static Logger logger = LoggerFactory.getLogger(Definition.class);
     private final static String TITLE = "title";
     private final static String OSCONFIG = "_osConfig";
+    private final static String DEFINITIONS = "definitions";
+    private final static String PROPERTIES = "properties";
+    private final static String REF = "$ref";
+    private final static String TYPE = "type";
+    private final static String OBJECT = "object";
 
     private String content;
     private String title;
 
-    private OSSchemaConfiguration osSchemaConfiguration;
+    private Map<String, String> subSchemaNames = new HashMap<>();
+
+    private OSSchemaConfiguration osSchemaConfiguration = new OSSchemaConfiguration();
 
     /**
      * To parse a jsonNode of given schema type
      * 
-     * @param schema
+     * @param schemaNode
      */
-    public Definition(JsonNode schema) {
-        content = schema.toString();
-        if(!schema.has(TITLE))
-            throw new RuntimeException(TITLE + " not found for schema, " + schema);
-        title = schema.get(TITLE).asText();
+    public Definition(JsonNode schemaNode) {
+        content = schemaNode.toString();
+        if(!schemaNode.has(TITLE))
+            throw new RuntimeException(TITLE + " not found for schema, " + schemaNode);
+        title = schemaNode.get(TITLE).asText();
         ObjectMapper mapper = new ObjectMapper();
 
-        JsonNode configJson = schema.get(OSCONFIG);
+        JsonNode configJson = schemaNode.get(OSCONFIG);
         if (null != configJson) {
             try {
                 osSchemaConfiguration = mapper.treeToValue(configJson, OSSchemaConfiguration.class);
@@ -40,11 +51,31 @@ public class Definition {
                 logger.debug(title + " does not have OS configuration.");
             }
         }
-        
-        //Default when no config provided
-        if (osSchemaConfiguration == null) {
-            osSchemaConfiguration = new OSSchemaConfiguration();
-        }
+
+        // Iterate over all properties in the current definition
+        JsonNode properties = schemaNode.get(DEFINITIONS).get(title).get(PROPERTIES);
+        properties.fields().forEachRemaining(field -> {
+            JsonNode typeTextNode = field.getValue().get(TYPE);
+            boolean isArrayType = typeTextNode != null && typeTextNode.asText().equals("array");
+
+            JsonNode refTextNode = field.getValue().get(REF);
+            if (isArrayType) {
+                refTextNode = field.getValue().get("items").get(REF);
+            }
+
+            boolean isRefValid = isRefNode(refTextNode);
+            if (isRefValid) {
+                String refVal = refTextNode.asText();
+                logger.debug("{}.{} is a ref field with value {}", title, field.getKey(), refVal);
+                addFieldSchema(field.getKey(),
+                        refVal.substring(refVal.lastIndexOf("/") + 1));
+            }
+        });
+    }
+
+
+    private boolean isRefNode(JsonNode refTextNode) {
+        return (refTextNode != null && !refTextNode.isMissingNode() && !refTextNode.isNull());
     }
 
     /**
@@ -65,8 +96,23 @@ public class Definition {
         return content;
     }
 
+    /**
+     * Gets the OSSchemaConfiguration
+     * @return
+     */
     public OSSchemaConfiguration getOsSchemaConfiguration() {
         return osSchemaConfiguration;
     }
-    
+
+    public void addFieldSchema(String fieldName, String definitionName) {
+        subSchemaNames.put(fieldName, definitionName);
+    }
+
+    public String getDefinitionNameForField(String name) {
+        return subSchemaNames.getOrDefault(name, null);
+    }
+
+    public Map<String, String> getSubSchemaNames() {
+        return subSchemaNames;
+    }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/Definition.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/Definition.java
@@ -53,24 +53,28 @@ public class Definition {
         }
 
         // Iterate over all properties in the current definition
-        JsonNode properties = schemaNode.get(DEFINITIONS).get(title).get(PROPERTIES);
-        properties.fields().forEachRemaining(field -> {
-            JsonNode typeTextNode = field.getValue().get(TYPE);
-            boolean isArrayType = typeTextNode != null && typeTextNode.asText().equals("array");
+        JsonNode defnTitle = schemaNode.get(DEFINITIONS).get(title);
+        JsonNode properties = null;
+        if (null != defnTitle) {
+            properties = defnTitle.get(PROPERTIES);
+            properties.fields().forEachRemaining(field -> {
+                JsonNode typeTextNode = field.getValue().get(TYPE);
+                boolean isArrayType = typeTextNode != null && typeTextNode.asText().equals("array");
 
-            JsonNode refTextNode = field.getValue().get(REF);
-            if (isArrayType) {
-                refTextNode = field.getValue().get("items").get(REF);
-            }
+                JsonNode refTextNode = field.getValue().get(REF);
+                if (isArrayType) {
+                    refTextNode = field.getValue().get("items").get(REF);
+                }
 
-            boolean isRefValid = isRefNode(refTextNode);
-            if (isRefValid) {
-                String refVal = refTextNode.asText();
-                logger.debug("{}.{} is a ref field with value {}", title, field.getKey(), refVal);
-                addFieldSchema(field.getKey(),
-                        refVal.substring(refVal.lastIndexOf("/") + 1));
-            }
-        });
+                boolean isRefValid = isRefNode(refTextNode);
+                if (isRefValid) {
+                    String refVal = refTextNode.asText();
+                    logger.debug("{}.{} is a ref field with value {}", title, field.getKey(), refVal);
+                    addFieldSchema(field.getKey(),
+                            refVal.substring(refVal.lastIndexOf("/") + 1));
+                }
+            });
+        }
     }
 
 

--- a/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/DefinitionsManager.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.PostConstruct;
+
+import org.apache.commons.collections.map.HashedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +24,7 @@ public class DefinitionsManager {
     private static Logger logger = LoggerFactory.getLogger(DefinitionsManager.class);
 
     private Map<String, Definition> definitionMap = new HashMap<>();
+    private Map<String, Definition> derivedDefinitionMap = new HashedMap();
     
     private OSResourceLoader osResourceLoader;
     
@@ -47,13 +50,14 @@ public class DefinitionsManager {
             definitionMap.putIfAbsent(definition.getTitle(), definition);
         }
 
+        derivedDefinitionMap.putAll(definitionMap);
         Set<Definition> loadedDefinitionsSet = new HashSet<>();
         loadedDefinitionsSet.addAll(definitionMap.values());
 
         // CAVEAT: attribute names must be distinct to not cause definition collisions.
         loadedDefinitionsSet.forEach(def -> {
             def.getSubSchemaNames().forEach((fieldName, defnName) -> {
-                definitionMap.putIfAbsent(fieldName, definitionMap.get(defnName));
+                derivedDefinitionMap.putIfAbsent(fieldName, definitionMap.get(defnName));
             });
         });
 
@@ -89,7 +93,7 @@ public class DefinitionsManager {
      * @return
      */
     public Definition getDefinition(String title) {
-        return definitionMap.getOrDefault(title, null);
+        return derivedDefinitionMap.getOrDefault(title, null);
     }
 
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/PrivateField.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/PrivateField.java
@@ -1,20 +1,25 @@
 package io.opensaber.registry.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.opensaber.registry.exception.EncryptionException;
 import io.opensaber.registry.service.EncryptionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 public class PrivateField {
-
     @Autowired
     public EncryptionService encryptionService;
     @Autowired
     public DefinitionsManager definitionsManager;
+    private Logger logger = LoggerFactory.getLogger(PrivateField.class);
 
     /**
      * Identifies the keys in the rootNode that needs to be encrypted/decrypted
@@ -29,8 +34,6 @@ public class PrivateField {
             if (entryValue.isValueNode()) {
                 if (privatePropertyLst.contains(entry.getKey()))
                     plainKeyValues.put(entry.getKey(), entryValue.asText());
-            } else if (entryValue.isObject()) {
-                plainKeyValues.putAll(getPrivateFields(entryValue, privatePropertyLst));
             }
         });
         return plainKeyValues;
@@ -53,10 +56,72 @@ public class PrivateField {
                 String privateFieldValue = privateFieldMap.get(entry.getKey()).toString();
                 JsonNode encryptedValNode = JsonNodeFactory.instance.textNode(privateFieldValue);
                 entry.setValue(encryptedValNode);
-            } else if (entryValue.isObject()) {
-                replacePrivateFields(entryValue, privatePropertyLst, privateFieldMap);
             }
         });
         return rootNode;
+    }
+
+    protected Map<String, Object> performOperation(Map<String, Object> plainMap) throws EncryptionException {
+        return null;
+    }
+
+    protected JsonNode processPrivateFields(JsonNode element, String rootDefinitionName, String childFieldName) throws EncryptionException {
+        JsonNode tempElement = element;
+        Definition definition = definitionsManager.getDefinition(rootDefinitionName);;
+        if (null != childFieldName) {
+            String defnName = definition.getDefinitionNameForField(childFieldName);
+            definition = definitionsManager.getDefinition(defnName);
+            logger.debug("Got child name definition");
+        }
+
+        List<String> privatePropertyLst = definition.getOsSchemaConfiguration().getPrivateFields();
+        Map<String, Object> plainMap = getPrivateFields(element, privatePropertyLst);
+        if (null != plainMap && !plainMap.isEmpty()) {
+            Map<String, Object> encodedMap = performOperation(plainMap);
+            tempElement = replacePrivateFields(element, privatePropertyLst, encodedMap);
+        }
+        return tempElement;
+    }
+
+    private void processArray(ArrayNode arrayNode, String rootFieldName, String fieldName) throws EncryptionException {
+        for (JsonNode jsonNode : arrayNode) {
+            if (jsonNode.isObject()) {
+                process(jsonNode, rootFieldName, fieldName);
+            }
+        }
+    }
+
+    protected JsonNode process(JsonNode jsonNode, String rootFieldName, String fieldName) throws EncryptionException {
+        processPrivateFields(jsonNode, rootFieldName, fieldName);
+
+        String tempFieldName = fieldName;
+        if (null == tempFieldName) {
+            tempFieldName = rootFieldName;
+        }
+
+        JsonNode toProcess = jsonNode;
+        JsonNode childNode = jsonNode.get(tempFieldName);
+        if (null != childNode) {
+            toProcess = childNode;
+        }
+
+        Iterator<Map.Entry<String, JsonNode>> fieldsItr = toProcess.fields();
+        while (fieldsItr.hasNext()) {
+            try {
+                Map.Entry<String, JsonNode> entry = fieldsItr.next();
+                JsonNode entryValue = entry.getValue();
+                logger.debug("Processing {}.{} -> {}", tempFieldName, entry.getKey(), entry.getValue());
+
+                if (entryValue.isObject()) {
+                    // Recursive calls
+                    process(entryValue, tempFieldName, entry.getKey());
+                } else if (entryValue.isArray()) {
+                    processArray((ArrayNode) entryValue, tempFieldName, entry.getKey());
+                }
+            } catch (EncryptionException e) {
+                e.printStackTrace();
+            }
+        }
+        return jsonNode;
     }
 }

--- a/java/registry/src/main/java/io/opensaber/registry/util/ReadConfiguratorFactory.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ReadConfiguratorFactory.java
@@ -1,5 +1,10 @@
 package io.opensaber.registry.util;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
 public class ReadConfiguratorFactory {
     public static ReadConfigurator getDefault() {
         ReadConfigurator configurator = new ReadConfigurator();
@@ -21,6 +26,24 @@ public class ReadConfiguratorFactory {
         } else {
             return getDefault();
         }
+    }
+
+    public static ReadConfigurator getOne(boolean withSignatures, JsonNode configRequested) {
+        ReadConfigurator readConfigurator = null;
+        if (configRequested != null && !configRequested.isNull()) {
+            try {
+                readConfigurator = new ObjectMapper().readValue(configRequested.toString(),
+                        ReadConfigurator.class);
+            } catch (IOException e) {
+                // No explicit config requested. Not a problem.
+                readConfigurator = null;
+            }
+        }
+
+        if (null == readConfigurator) {
+            readConfigurator = getOne(withSignatures);
+        }
+        return readConfigurator;
     }
 
     public static ReadConfigurator getForUpdateValidation() {

--- a/java/registry/src/main/java/io/opensaber/registry/util/ViewTemplateManager.java
+++ b/java/registry/src/main/java/io/opensaber/registry/util/ViewTemplateManager.java
@@ -68,8 +68,7 @@ public class ViewTemplateManager {
      * @throws JsonMappingException
      * @throws IOException
      */
-	public ViewTemplate getViewTemplate(JsonNode requestNode)
-			throws JsonParseException, JsonMappingException, IOException {
+	public ViewTemplate getViewTemplate(JsonNode requestNode) {
 
 		ViewTemplate viewTemp = null;
 		String name = null;
@@ -91,17 +90,18 @@ public class ViewTemplateManager {
 	}
     
 	private ViewTemplate getViewTemplateByContent(String templateContent)
-			throws JsonParseException, JsonMappingException, IOException {
+			throws IOException {
 		return mapper.readValue(templateContent, ViewTemplate.class);
 	}
 
-	public boolean isPrivateFieldEnabled(ViewTemplate viewTemplate, String entityType){
+	// TODO = this cannot be determined by the root level node alone. Check subschema
+	public boolean isPrivateFieldEnabled(ViewTemplate viewTemplate, String entityType) {
 		boolean privateFieldEnabled = false;
 		List<Field> fieldList = viewTemplate.getFields();
 		Definition definition = definitionsManager.getDefinition(entityType);
 		List<String> privateFields = definition.getOsSchemaConfiguration().getPrivateFields();
-		for(Field field : fieldList) {
-			if(privateFields.contains(field.getName())){
+		for (Field field : fieldList) {
+			if(privateFields.contains(field.getName())) {
 				privateFieldEnabled = true;
 				break;
 			}

--- a/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
+++ b/java/validators/json/jsonschema/src/main/java/io/opensaber/validators/json/jsonschema/JsonValidationServiceImpl.java
@@ -36,8 +36,9 @@ public class JsonValidationServiceImpl implements IValidate {
 				String definitionContent = definitionMap.get(entityType);
                 JSONObject rawSchema = new JSONObject(definitionContent);
 
+				String scopeUrl = String.format("http://localhost:%d/_schemas/", port);
 				SchemaLoader schemaLoader = SchemaLoader.builder().schemaJson(rawSchema).draftV7Support()
-						.resolutionScope("http://localhost:9080/_schemas/").build();
+						.resolutionScope(scopeUrl).build();
 				schema = schemaLoader.load().build();
 				entitySchemaMap.put(entityType, schema);
 			} catch (Exception ioe) {
@@ -65,6 +66,7 @@ public class JsonValidationServiceImpl implements IValidate {
 		}
 		return result;
 	}
+
     /**
      * Store all list of known definitions as definitionMap.
      * Must get populated before creating the schema.
@@ -75,7 +77,5 @@ public class JsonValidationServiceImpl implements IValidate {
     @Override
     public void addDefinitions(String definitionTitle, String definitionContent) {
         definitionMap.put(definitionTitle, definitionContent);
-       
     }
-
 }


### PR DESCRIPTION
While load definitions, also make a note of the sub-schemas referred and their corresponding definitions.
Extend PrivateField class functions to support child level object configurations - this will help in encrypt (write) and decrypt (read) operations.

Testing
1. Customer has tried this for their own schemas and confirmed one.
2. Existing schemas load is successful with signatures enabled.
3. 3 level deep child and array of objects works with encryption/decryption.

TODO: Trying an API based testing to smoothen this.