### PR TITLE
Docs: Update readme docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Open Software Archetype for Building Electronic Registries, shortly called OpenS
 
 Registry is a shared digital infrastructure which enables authorized data repositories to publish appropriate data and metadata about a user/entity along with the link to the repository in a digitally signed form and allows data owners to provide authorized access to other users/entities in controlled manner for digital verification and usage.
 
-See [documentation here](https://docs.sunbirdrc.dev/) and [Wiki](https://github.com/project-sunbird/open-saber/wiki) for more details.
+See [documentation here](https://sunbirdrc.dev/) and [Wiki](https://github.com/project-sunbird/open-saber/wiki) for more details.

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Open Software Archetype for Building Electronic Registries, shortly called OpenS
 
 Registry is a shared digital infrastructure which enables authorized data repositories to publish appropriate data and metadata about a user/entity along with the link to the repository in a digitally signed form and allows data owners to provide authorized access to other users/entities in controlled manner for digital verification and usage.
 
-See [documentation here](https://opensaber.io/) and [Wiki](https://github.com/project-sunbird/open-saber/wiki) for more details.
+See [documentation here](https://docs.sunbirdrc.dev/) and [Wiki](https://github.com/project-sunbird/open-saber/wiki) for more details.


### PR DESCRIPTION
The current documentation link in the README points the user to https://opensaber.io, which gives the following warning in Firefox:

![image](https://user-images.githubusercontent.com/34235681/134760541-c29b215e-d068-4bfd-b489-8bf0d12fd134.png)

This PR changes the link to https://sunbirdrc.dev/ (the original https://opensaber.io link redirects to https://sunbirdrc.dev/ anyway)